### PR TITLE
require pry-byebug in cli.rb which Pry will load in Pry.init

### DIFF
--- a/lib/pry-byebug/cli.rb
+++ b/lib/pry-byebug/cli.rb
@@ -1,0 +1,1 @@
+require 'pry-byebug'


### PR DESCRIPTION
I ran into an issue where I would get the error "ArgumentError: uncaught throw :breakout_nav" if I do this:

``` ruby
require 'pry'
# require 'pry-byebug'
binding.pry
puts "next statement"
[1] pry(main)> next
```

This pull request resolves that by using cli.rb to load pry-byebug before pry-core has a chance to call the un-extended Pry.start.  I can follow up with more details if needed.
