### PR TITLE
Fixes bug when debugger does not stops at the breakpoint set by method name

### DIFF
--- a/test/breakpoints_test.rb
+++ b/test/breakpoints_test.rb
@@ -1,14 +1,34 @@
 require 'test_helper'
 
 class BreakpointsTest < MiniTest::Spec
-
-  def test_add_raises_argument_error
+  def test_add_file_raises_argument_error
     Pry.stubs eval_path: "something"
     File.stubs :exist?
     assert_raises(ArgumentError) do
-      PryByebug::Breakpoints.add("file", 1)
+      PryByebug::Breakpoints.add_file("file", 1)
     end
   end
 
-end
+  class Tester
+    def self.class_method; end
+    def instance_method; end
+  end
 
+  def test_add_method_adds_instance_method_breakpoint
+    Pry.stub :processor, PryByebug::Processor.new do
+      PryByebug::Breakpoints.add_method 'BreakpointsTest::Tester#instance_method'
+      bp = Byebug.breakpoints.last
+      assert_equal 'BreakpointsTest::Tester', bp.source
+      assert_equal 'instance_method', bp.pos
+    end
+  end
+
+  def test_add_method_adds_class_method_breakpoint
+    Pry.stub :processor, PryByebug::Processor.new do
+      PryByebug::Breakpoints.add_method 'BreakpointsTest::Tester.class_method'
+      bp = Byebug.breakpoints.last
+      assert_equal 'BreakpointsTest::Tester', bp.source
+      assert_equal 'class_method', bp.pos
+    end
+  end
+end


### PR DESCRIPTION
When you're setting breakpoint by method name with `break SomeClass#some_method` command, `pry-byebug` converts it to filename and line number (line where `def some_method` statement is located). For some reason, it does not works (`byebug` never stops at this breakpoint). Easy fix is to increment `method_object.source_location` line number by 1 so that it points to the 1st line of the method, but it may not work properly for empty / one line methods.

It looks like you can pass method/class name instead of file name/line number to `byebug` directly which is exactly what this PR is all about.
