### PR TITLE
Easy fix for bug when debugger does not stops on method

### DIFF
--- a/lib/pry-byebug/commands.rb
+++ b/lib/pry-byebug/commands.rb
@@ -164,7 +164,9 @@ module PryByebug
             [$1, $2]
           else               # Method or class name
             self.args = [place]
-            method_object.source_location
+            file, line = method_object.source_location
+            line += 1 if method_object.source.lines.count > 2
+            [file, line]
           end
 
         print_full_breakpoint Breakpoints.add(file, line.to_i, condition)


### PR DESCRIPTION
Complement PR related to https://github.com/deivid-rodriguez/pry-byebug/pull/15 just in case.

Important note: it does not allows to put a break on empty method.
