### PR TITLE
Update byebug dependency 2.7 -> 3.0

### DIFF
--- a/pry-byebug.gemspec
+++ b/pry-byebug.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.0.0'
 
   gem.add_runtime_dependency 'pry', '~> 0.9.12'
-  gem.add_runtime_dependency 'byebug', '~> 2.7'
+  gem.add_runtime_dependency 'byebug', '~> 3.0'
 end


### PR DESCRIPTION
Now that byebug 3.0.0 is out, people using pry-byebug will want to be
able to use the newer version. This commit bumps the dependency to ~>
3.0, allowing the new version to be installed.

After updating to 3.1.2, the test suite still passes.

Closes #26
