### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # pry-byebug
 [![Version][VersionBadge]][VersionURL]
 [![Build][TravisBadge]][TravisURL]
+[![Inline docs][InchCIBadge]](InchCIURL)
 [![Gittip][GittipBadge]][GittipURL]
 
 _Fast execution control in Pry_
@@ -107,5 +108,7 @@ Patches and bug reports are welcome.
 [VersionURL]: http://badge.fury.io/rb/pry-byebug
 [TravisBadge]: https://secure.travis-ci.org/deivid-rodriguez/pry-byebug.png
 [TravisURL]: http://travis-ci.org/deivid-rodriguez/pry-byebug
+[InchCIBadge]: http://inch-ci.org/github/deivid-rodriguez/pry-byebug.svg?branch=master
+[InchCIURL]: http://inch-ci.org/github/deivid-rodriguez/pry-byebug
 [GittipBadge]: http://img.shields.io/gittip/deivid-rodriguez.svg
 [GittipURL]: https://www.gittip.com/deivid-rodriguez


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-ci.org/github/deivid-rodriguez/pry-byebug.png)](http://inch-ci.org/github/deivid-rodriguez/pry-byebug)

The badge links to [Inch CI](http://inch-ci.org), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. Your status page is http://inch-ci.org/github/deivid-rodriguez/pry-byebug/

Inch CI is still in its infancy (3 months old), but already used by projects like [Pry](https://github.com/pry/pry), [Bundler](https://github.com/bundler/bundler), [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), and [ROM](https://github.com/rom-rb/rom).

What do you think?
