### PR TITLE
Update README with instructions to repeat last command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ optional numeric argument to step multiple lines. Aliased to `n`
 
 **continue:** Continue program execution and end the Pry session. Aliased to `c`
 
+To configure the `Enter` key to repeat the last command (e.g., `step` or
+`next`), add this to your ~/.pryrc file:
+
+    # Hit Enter to repeat last command
+    Pry::Commands.command /^$/, "repeat last command" do
+      _pry_.run_command Pry.history.to_a.last
+    end
+
 
 ## Breakpoints
 


### PR DESCRIPTION
It's useful to have the `Enter` key repeat the last command when debugging, so I added succinct instructions to the readme.
