### PR TITLE
Removed default stepping aliases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.4 (2014-17-11)
+
+* Reverted automatic aliases as they commonly conflict with local variables.
+
 ## 1.3.3 (2014-25-06)
 
 * Relaxes pry dependency to support pry 0.10 series and further minor version
@@ -42,7 +46,7 @@ level releases.
 
 
 ## 1.1.0 (2013-06-06)
- 
+
 * Adds a test suite (thanks @teeparham!)
 * Uses byebug ~> 1.4.0
 * Uses s, n, f and c aliases by default (thanks @jgakos!)

--- a/README.md
+++ b/README.md
@@ -38,15 +38,41 @@ to use it to debug your tests!_
 ## Execution Commands
 
 **step:** Step execution into the next line or method. Takes an optional numeric
-argument to step multiple times. Aliased to `s`
+argument to step multiple times.
 
 **next:** Step over to the next line within the same frame. Also takes an
-optional numeric argument to step multiple lines. Aliased to `n`
+optional numeric argument to step multiple lines.
 
-**finish:** Execute until current stack frame returns. Aliased to `f`
+**finish:** Execute until current stack frame returns.
 
-**continue:** Continue program execution and end the Pry session. Aliased to `c`
+**continue:** Continue program execution and end the Pry session.
 
+## Matching Byebug Behaviour
+
+The 'n', 's', 'c' and 'f' aliases for the stepping commands were removed
+by default because they commonly conflict with scratch variable names.
+It's very easy to re-enable them by adding the following shortcuts to your
+`~/.pryrc` file:
+
+```ruby
+if defined?(PryByebug)
+  Pry.commands.alias_command 'c', 'continue'
+  Pry.commands.alias_command 's', 'step'
+  Pry.commands.alias_command 'n', 'next'
+  Pry.commands.alias_command 'f', 'finish'
+end
+```
+
+Also, you might find it useful to repeat the last command by just hitting
+the `Enter` key (e.g., with `step` or `next`). To achieve that, add this to
+your `~/.pryrc` file:
+
+```ruby
+# Hit Enter to repeat last command
+Pry::Commands.command /^$/, "repeat last command" do
+  _pry_.run_command Pry.history.to_a.last
+end
+```
 
 ## Breakpoints
 

--- a/lib/pry-byebug/commands.rb
+++ b/lib/pry-byebug/commands.rb
@@ -8,7 +8,6 @@ module PryByebug
 
       banner <<-BANNER
         Usage: step [TIMES]
-        Aliases: s
 
         Step execution forward. By default, moves a single step.
 
@@ -23,14 +22,12 @@ module PryByebug
         breakout_navigation :step, args.first
       end
     end
-    alias_command 's', 'step'
 
     create_command 'next' do
       description 'Execute the next line within the current stack frame.'
 
       banner <<-BANNER
         Usage: next [LINES]
-        Aliases: n
 
         Step over within the same frame. By default, moves forward a single
         line.
@@ -46,14 +43,12 @@ module PryByebug
         breakout_navigation :next, args.first
       end
     end
-    alias_command 'n', 'next'
 
     create_command 'finish' do
       description 'Execute until current stack frame returns.'
 
       banner <<-BANNER
         Usage: finish
-        Aliases: f
       BANNER
 
       def process
@@ -61,14 +56,12 @@ module PryByebug
         breakout_navigation :finish
       end
     end
-    alias_command 'f', 'finish'
 
     create_command 'continue' do
       description 'Continue program execution and end the Pry session.'
 
       banner <<-BANNER
         Usage: continue
-        Aliases: c
       BANNER
 
       def process
@@ -76,7 +69,6 @@ module PryByebug
         run 'exit-all'
       end
     end
-    alias_command 'c', 'continue'
 
     create_command 'break' do
       description 'Set or edit a breakpoint.'

--- a/lib/pry-byebug/version.rb
+++ b/lib/pry-byebug/version.rb
@@ -1,3 +1,3 @@
 module PryByebug
-  VERSION = '1.3.3'
+  VERSION = '1.3.4'
 end


### PR DESCRIPTION
Fixes #34 

Patched on top 1.3.3 because our dev team is witnessing some instability with 2.x.