### PR TITLE
Fix warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@ require 'rake/testtask'
 desc 'Run tests'
 Rake::TestTask.new(:test) do |t|
   t.libs << 'test'
+  t.ruby_opts += ["-w"]
   t.pattern = 'test/**/*_test.rb'
 end
 

--- a/lib/byebug/processors/pry_processor.rb
+++ b/lib/byebug/processors/pry_processor.rb
@@ -97,7 +97,7 @@ module Byebug
       new_binding = context.frame_binding(0)
 
       run do
-        if @pry
+        if defined?(@pry) && @pry
           @pry.repl(new_binding)
         else
           @pry = Pry.start_without_pry_byebug(new_binding)

--- a/lib/byebug/processors/pry_processor.rb
+++ b/lib/byebug/processors/pry_processor.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'byebug'
 
 module Byebug

--- a/lib/pry-byebug.rb
+++ b/lib/pry-byebug.rb
@@ -1,3 +1,4 @@
+require 'pry'
 require 'pry-byebug/base'
 require 'pry-byebug/pry_ext'
 require 'pry/commands/stepping'

--- a/lib/pry-byebug/cli.rb
+++ b/lib/pry-byebug/cli.rb
@@ -1,0 +1,4 @@
+require 'pry-byebug/base'
+require 'pry-byebug/pry_ext'
+require 'pry/commands/stepping'
+require 'pry/commands/breakpoint'

--- a/lib/pry-byebug/cli.rb
+++ b/lib/pry-byebug/cli.rb
@@ -1,1 +1,0 @@
-require 'pry-byebug'

--- a/lib/pry-byebug/pry_ext.rb
+++ b/lib/pry-byebug/pry_ext.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'byebug/processors/pry_processor'
 
 class << Pry

--- a/lib/pry/commands/breakpoint.rb
+++ b/lib/pry/commands/breakpoint.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'pry/byebug/breakpoints'
 
 #

--- a/lib/pry/commands/stepping.rb
+++ b/lib/pry/commands/stepping.rb
@@ -1,5 +1,3 @@
-require 'pry'
-
 #
 # Main Pry class.
 #

--- a/test/breakpoints_test.rb
+++ b/test/breakpoints_test.rb
@@ -94,7 +94,7 @@ class BreakpointsTestCommands < Minitest::Spec
       before do
         @input = InputTester.new('break Break1Example#a')
         redirect_pry_io(@input, @output) { load break_first_file }
-        @line = 7
+        @line = 11
         @regexp = /  Breakpoint (?<id>\d+): Break1Example#a \(Enabled\)/
       end
 
@@ -105,7 +105,7 @@ class BreakpointsTestCommands < Minitest::Spec
       before do
         @input = InputTester.new('break Break1Example#c!')
         redirect_pry_io(@input, @output) { load break_first_file }
-        @line = 17
+        @line = 21
         @regexp = /  Breakpoint (?<id>\d+): Break1Example#c! \(Enabled\)/
       end
 

--- a/test/breakpoints_test.rb
+++ b/test/breakpoints_test.rb
@@ -73,7 +73,9 @@ class BreakpointsTestCommands < Minitest::Spec
   before do
     Pry.color, Pry.pager, Pry.hooks = false, false, Pry::DEFAULT_HOOKS
     @input = InputTester.new 'break --delete-all'
-    redirect_pry_io(@input, StringIO.new) { binding.pry }
+    redirect_pry_io(@input, StringIO.new) do
+      binding.pry # rubocop:disable Lint/Debugger
+    end
     Object.send :remove_const, :Break1Example if defined? Break1Example
     Object.send :remove_const, :Break2Example if defined? Break2Example
     @output = StringIO.new

--- a/test/breakpoints_test.rb
+++ b/test/breakpoints_test.rb
@@ -84,10 +84,10 @@ class BreakpointsTestCommands < Minitest::Spec
   describe 'Set Breakpoints' do
     describe 'set by line number' do
       before do
-        @input = InputTester.new('break 8')
+        @input = InputTester.new('break 6')
         redirect_pry_io(@input, @output) { load break_first_file }
-        @line = 8
-        @regexp = /^  Breakpoint (?<id>\d+): #{break_first_file} @ 8 \(Enabled\)/
+        @line = 6
+        @regexp = /^  Breakpoint (?<id>\d+): #{break_first_file} @ 6 \(Enabled\)/
       end
 
       include BreakpointSpecs
@@ -97,7 +97,7 @@ class BreakpointsTestCommands < Minitest::Spec
       before do
         @input = InputTester.new('break Break1Example#a')
         redirect_pry_io(@input, @output) { load break_first_file }
-        @line = 7
+        @line = 5
         @regexp = /  Breakpoint (?<id>\d+): Break1Example#a \(Enabled\)/
       end
 
@@ -108,7 +108,7 @@ class BreakpointsTestCommands < Minitest::Spec
       before do
         @input = InputTester.new('break Break1Example#c!')
         redirect_pry_io(@input, @output) { load break_first_file }
-        @line = 17
+        @line = 15
         @regexp = /  Breakpoint (?<id>\d+): Break1Example#c! \(Enabled\)/
       end
 

--- a/test/breakpoints_test.rb
+++ b/test/breakpoints_test.rb
@@ -52,9 +52,10 @@ module BreakpointSpecs
   end
 
   def test_shows_breakpoint_hit
-    @output.string.must_match(@regexp)
-    match = @output.string.match(@regexp)
-    @output.string.must_match(/^  Breakpoint #{match[:id]}\. First hit/)
+    result = @output.string
+    result.must_match(@regexp)
+    match = result.match(@regexp)
+    result.must_match(/^  Breakpoint #{match[:id]}\. First hit/)
   end
 
   def test_shows_breakpoint_line
@@ -71,21 +72,20 @@ class BreakpointsTestCommands < Minitest::Spec
 
   before do
     Pry.color, Pry.pager, Pry.hooks = false, false, Pry::DEFAULT_HOOKS
+    @input = InputTester.new 'break --delete-all'
+    redirect_pry_io(@input, StringIO.new) { binding.pry }
+    Object.send :remove_const, :Break1Example if defined? Break1Example
+    Object.send :remove_const, :Break2Example if defined? Break2Example
     @output = StringIO.new
   end
 
   describe 'Set Breakpoints' do
-    before do
-      @input = InputTester.new 'break --delete-all'
-      redirect_pry_io(@input, @output) { load break_first_file }
-    end
-
     describe 'set by line number' do
       before do
-        @input = InputTester.new('break 7')
+        @input = InputTester.new('break 8')
         redirect_pry_io(@input, @output) { load break_first_file }
-        @line = 7
-        @regexp = /  Breakpoint (?<id>\d+): #{break_first_file} @ 7 \(Enabled\)/
+        @line = 8
+        @regexp = /^  Breakpoint (?<id>\d+): #{break_first_file} @ 8 \(Enabled\)/
       end
 
       include BreakpointSpecs
@@ -95,7 +95,7 @@ class BreakpointsTestCommands < Minitest::Spec
       before do
         @input = InputTester.new('break Break1Example#a')
         redirect_pry_io(@input, @output) { load break_first_file }
-        @line = 11
+        @line = 7
         @regexp = /  Breakpoint (?<id>\d+): Break1Example#a \(Enabled\)/
       end
 
@@ -106,7 +106,7 @@ class BreakpointsTestCommands < Minitest::Spec
       before do
         @input = InputTester.new('break Break1Example#c!')
         redirect_pry_io(@input, @output) { load break_first_file }
-        @line = 21
+        @line = 17
         @regexp = /  Breakpoint (?<id>\d+): Break1Example#c! \(Enabled\)/
       end
 
@@ -117,7 +117,7 @@ class BreakpointsTestCommands < Minitest::Spec
       before do
         @input = InputTester.new('break #b')
         redirect_pry_io(@input, @output) { load break_second_file }
-        @line = 11
+        @line = 7
         @regexp = /  Breakpoint (?<id>\d+): Break2Example#b \(Enabled\)/
       end
 
@@ -127,7 +127,7 @@ class BreakpointsTestCommands < Minitest::Spec
 
   describe 'List breakpoints' do
     before do
-      @input = InputTester.new('break --delete-all', 'break #b', 'breakpoints')
+      @input = InputTester.new('break #b', 'breakpoints')
       redirect_pry_io(@input, @output) { load break_second_file }
     end
 

--- a/test/breakpoints_test.rb
+++ b/test/breakpoints_test.rb
@@ -52,6 +52,7 @@ module BreakpointSpecs
   end
 
   def test_shows_breakpoint_hit
+    @output.string.must_match(@regexp)
     match = @output.string.match(@regexp)
     @output.string.must_match(/^  Breakpoint #{match[:id]}\. First hit/)
   end

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -36,7 +36,7 @@ class CommandsTest < MiniTest::Spec
 
     describe 'multiple step' do
       before do
-        @input, @line = InputTester.new('step 2'), 12
+        @input, @line = InputTester.new('step 5'), 16
         redirect_pry_io(@input, @output) { load step_file }
       end
 
@@ -56,7 +56,7 @@ class CommandsTest < MiniTest::Spec
 
     describe 'multiple step' do
       before do
-        @input, @line = InputTester.new('break --delete-all', 'next 2'), 25
+        @input, @line = InputTester.new('break --delete-all', 'next 2'), 29
         redirect_pry_io(@input, @output) { load step_file }
       end
 
@@ -69,7 +69,7 @@ class CommandsTest < MiniTest::Spec
       @input = \
         InputTester.new 'break --delete-all', 'break 19', 'continue', 'finish'
       redirect_pry_io(@input, @output) { load step_file }
-      @line = 15
+      @line = 19
     end
 
     include SteppingSpecs

--- a/test/commands_test.rb
+++ b/test/commands_test.rb
@@ -20,6 +20,7 @@ class CommandsTest < MiniTest::Spec
   let(:step_file) { test_file('stepping') }
 
   before do
+    Object.send :remove_const, :SteppingExample if defined? SteppingExample
     Pry.color, Pry.pager, Pry.hooks = false, false, Pry::DEFAULT_HOOKS
     @output = StringIO.new
   end
@@ -36,7 +37,7 @@ class CommandsTest < MiniTest::Spec
 
     describe 'multiple step' do
       before do
-        @input, @line = InputTester.new('step 5'), 16
+        @input, @line = InputTester.new('step 2'), 12
         redirect_pry_io(@input, @output) { load step_file }
       end
 
@@ -56,7 +57,7 @@ class CommandsTest < MiniTest::Spec
 
     describe 'multiple step' do
       before do
-        @input, @line = InputTester.new('break --delete-all', 'next 2'), 29
+        @input, @line = InputTester.new('break --delete-all', 'next 2'), 25
         redirect_pry_io(@input, @output) { load step_file }
       end
 
@@ -69,7 +70,7 @@ class CommandsTest < MiniTest::Spec
       @input = \
         InputTester.new 'break --delete-all', 'break 19', 'continue', 'finish'
       redirect_pry_io(@input, @output) { load step_file }
-      @line = 19
+      @line = 15
     end
 
     include SteppingSpecs

--- a/test/examples/break1.rb
+++ b/test/examples/break1.rb
@@ -1,13 +1,9 @@
-binding.pry
-
+#
+#
 #
 # A toy example for testing break commands.
 #
 class Break1Example
-  undef a if method_defined? :a
-  undef b if method_defined? :b
-  undef c! if method_defined? :c!
-
   def a
     z = 2
     z + b
@@ -23,5 +19,7 @@ class Break1Example
     z
   end
 end
+
+binding.pry
 
 Break1Example.new.a

--- a/test/examples/break1.rb
+++ b/test/examples/break1.rb
@@ -4,6 +4,10 @@ binding.pry
 # A toy example for testing break commands.
 #
 class Break1Example
+  undef a if method_defined? :a
+  undef b if method_defined? :b
+  undef c! if method_defined? :c!
+
   def a
     z = 2
     z + b

--- a/test/examples/break1.rb
+++ b/test/examples/break1.rb
@@ -1,6 +1,4 @@
 #
-#
-#
 # A toy example for testing break commands.
 #
 class Break1Example

--- a/test/examples/break2.rb
+++ b/test/examples/break2.rb
@@ -2,10 +2,6 @@
 # Another toy example for testing break commands.
 #
 class Break2Example
-  undef a if method_defined? :a
-  undef b if method_defined? :b
-  undef c if method_defined? :c
-
   def a
     binding.pry
     z = 2

--- a/test/examples/break2.rb
+++ b/test/examples/break2.rb
@@ -2,6 +2,10 @@
 # Another toy example for testing break commands.
 #
 class Break2Example
+  undef a if method_defined? :a
+  undef b if method_defined? :b
+  undef c if method_defined? :c
+
   def a
     binding.pry
     z = 2

--- a/test/examples/deep_stepping.rb
+++ b/test/examples/deep_stepping.rb
@@ -6,4 +6,4 @@ new_str = 'string'.gsub!(/str/) do |_|
   binding.pry
 end
 
-new_str
+_foo = new_str

--- a/test/examples/stepping.rb
+++ b/test/examples/stepping.rb
@@ -30,4 +30,4 @@ ex = SteppingExample.new.method_a
   ex += 1
 end
 
-ex
+_foo = ex

--- a/test/examples/stepping.rb
+++ b/test/examples/stepping.rb
@@ -4,6 +4,10 @@ binding.pry
 # Toy class for testing steps
 #
 class SteppingExample
+  undef method_a if method_defined? :method_a
+  undef method_b if method_defined? :method_b
+  undef method_c if method_defined? :method_c
+
   def method_a
     z = 2
     z + method_b

--- a/test/examples/stepping.rb
+++ b/test/examples/stepping.rb
@@ -4,10 +4,6 @@ binding.pry
 # Toy class for testing steps
 #
 class SteppingExample
-  undef method_a if method_defined? :method_a
-  undef method_b if method_defined? :method_b
-  undef method_c if method_defined? :method_c
-
   def method_a
     z = 2
     z + method_b

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -14,6 +14,7 @@ class ProcessorTest < Minitest::Spec
     let(:step_file) { test_file('stepping') }
 
     before do
+      Object.send :remove_const, :SteppingExample if defined? SteppingExample
       @input = InputTester.new
       @output = StringIO.new
       redirect_pry_io(@input, @output) { load step_file }


### PR DESCRIPTION
Enables warnings during test run, and fixes the resulting warnings.

In combination with https://github.com/pry/pry/pull/1355 this makes pry-byebug run warning-free in environments where warnings are enabled.