### PR TITLE
Extend continue command with optional line number

### DIFF
--- a/lib/byebug/processors/pry_processor.rb
+++ b/lib/byebug/processors/pry_processor.rb
@@ -56,7 +56,7 @@ module Byebug
     #
     def perform(action, options = {})
       return unless [
-        :next, :step, :finish, :up, :down, :frame
+        :next, :step, :finish, :continue, :up, :down, :frame
       ].include?(action)
 
       send("perform_#{action}", options)
@@ -131,6 +131,14 @@ module Byebug
 
     def perform_finish(*)
       state.context.step_out(1)
+    end
+
+    def perform_continue(options)
+      line = options[:line] ? options[:line].to_i : ''
+
+      command = Byebug::ContinueCommand.new(state)
+      command.match("continue #{line}")
+      command.execute
     end
 
     def perform_up(options)

--- a/lib/pry/commands/stepping.rb
+++ b/lib/pry/commands/stepping.rb
@@ -64,13 +64,20 @@ class Pry
       description 'Continue program execution and end the Pry session.'
 
       banner <<-BANNER
-        Usage: continue
+        Usage: continue [LINE]
+
+        Continue program execution until the next breakpoint, or the program
+        ends. Optionally continue to the specified line number.
+
+        Examples:
+          continue   #=> Continue until the next breakpoint.
+          continue 4 #=> Continue to line number 4.
       BANNER
 
       def process
         PryByebug.check_file_context(target)
 
-        breakout_navigation :continue
+        breakout_navigation :continue, line: args.first
       end
     end
 

--- a/test/stepping_test.rb
+++ b/test/stepping_test.rb
@@ -75,4 +75,13 @@ class SteppingTest < MiniTest::Spec
 
     include SteppingSpecs
   end
+
+  describe 'Continue Command' do
+    before do
+      @input, @line = InputTester.new('continue 14', 'finish'), 14
+      redirect_pry_io(@input, @output) { load step_file }
+    end
+
+    include SteppingSpecs
+  end
 end


### PR DESCRIPTION
Addresses issue #56 by allowing an optional line number for the `continue` command.
