### PR TITLE
WIP: make it work with pry-remote

### DIFF
--- a/lib/byebug/processors/pry_processor.rb
+++ b/lib/byebug/processors/pry_processor.rb
@@ -28,6 +28,7 @@ module Byebug
     # Wrap a Pry REPL to catch navigational commands and act on them.
     #
     def run(&_block)
+      Byebug.start unless Byebug.started?
       @state ||= Byebug::RegularState.new(
         Byebug.current_context,
         [],

--- a/lib/pry-byebug/base.rb
+++ b/lib/pry-byebug/base.rb
@@ -20,6 +20,8 @@ module PryByebug
   end
   module_function :check_file_context
 
-  # Reference to currently running pry-remote server. Used by the processor.
-  attr_accessor :current_remote_server
+  class << self
+    # Reference to currently running pry-remote server. Used by the processor.
+    attr_accessor :current_remote_server
+  end
 end

--- a/lib/pry-byebug/pry_ext.rb
+++ b/lib/pry-byebug/pry_ext.rb
@@ -8,8 +8,14 @@ class << Pry
     @processor ||= Byebug::PryProcessor.new
 
     if target.is_a?(Binding) && PryByebug.file_context?(target)
-      # Wrap processor around the usual Pry.start to catch navigation commands
-      @processor.start
+      if PryByebug.current_remote_server
+        # Wrap processor around the usual Pry.start to catch navigation commands
+        @processor.run do
+          start_without_pry_byebug(target, options)
+        end
+      else
+        @processor.start
+      end
     else
       # No need for the tracer unless we have a file context to step through
       start_without_pry_byebug(target, options)


### PR DESCRIPTION
still very much a work in progress, but was a solid progression IMHO, hoping someone with a better understanding of all the things at play in this gem can move this along further/faster/better/etc.
trying to address #33 (pinning at `1.3.3` would break if i used the `break` command . . . which **severely** limited it's usefulness) and [this issue](https://github.com/Mon-Ouie/pry-remote/issues/61) 
what this does atm:
1. the pry repl shows up on the client like it should and works more or less like you'd expect until you use the `finish` or `continue` commands
2. not totally sure exactly what `finish` is doing now, but seems to be stopping a lot more places than it should
3. `continue` works to the extent that it'll get you to the next breakpoint you've set or go on with the execution of the program. . . but then it hangs inside pry remote

``` text
/usr/local/opt/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/pry-remote-0.1.8/lib/pry-remote.rb:307:in `sleep': Interrupt
    from /usr/local/opt/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/pry-remote-0.1.8/lib/pry-remote.rb:307:in `run'
    from /usr/local/opt/rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/pry-remote-0.1.8/bin/pry-remote:4:in `<top (required)>'
    from /usr/local/opt/rbenv/versions/2.2.2/bin/pry-remote:23:in `load'
    from /usr/local/opt/rbenv/versions/2.2.2/bin/pry-remote:23:in `<main>'
```

both these gems are great! it'd be awesome to get them playing nicely together!
