### PR TITLE
Delete never used cli.rb

### DIFF
--- a/lib/pry-byebug/cli.rb
+++ b/lib/pry-byebug/cli.rb
@@ -1,3 +1,0 @@
-require 'pry-byebug/base'
-require 'pry-byebug/pry_ext'
-require 'pry-byebug/commands'


### PR DESCRIPTION
cli.rb is loaded by pry at startup, looking for cli options to add to pry command options.
This file is slowing down pry startup by 50%, even it's not used.
It's ok to not exist, since pry checks it:
https://github.com/pry/pry/blob/master/lib/pry/plugins.rb#L38