### PR TITLE
Add backtrace command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Byebug 9 compatibility.
 
+### Added
+
+* A new `backtrace` command.
+
 ## 3.3.0 (2015-11-05)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ optional numeric argument to step multiple lines.
 
 ### Callstack navigation
 
+**backtrace:** Shows the current stack. You can use the numbers on the left
+side with the `frame` command to navigate the stack.
+
 **up:** Moves the stack frame up. Takes an optional numeric argument to move
 multiple frames.
 

--- a/lib/byebug/processors/pry_processor.rb
+++ b/lib/byebug/processors/pry_processor.rb
@@ -41,7 +41,15 @@ module Byebug
     # Set up a number of navigational commands to be performed by Byebug.
     #
     def perform(action, options = {})
-      return unless %i(next step finish up down frame).include?(action)
+      return unless %i(
+        backtrace
+        down
+        finish
+        frame
+        next
+        step
+        up
+      ).include?(action)
 
       send("perform_#{action}", options)
     end
@@ -107,6 +115,12 @@ module Byebug
           @pry = Pry.start_without_pry_byebug(new_binding)
         end
       end
+    end
+
+    def perform_backtrace(_options)
+      Byebug::WhereCommand.new(self, 'backtrace').execute
+
+      resume_pry
     end
 
     def perform_next(options)

--- a/lib/pry-byebug/commands.rb
+++ b/lib/pry-byebug/commands.rb
@@ -1,3 +1,4 @@
+require 'pry-byebug/commands/backtrace'
 require 'pry-byebug/commands/next'
 require 'pry-byebug/commands/step'
 require 'pry-byebug/commands/continue'

--- a/lib/pry-byebug/commands/backtrace.rb
+++ b/lib/pry-byebug/commands/backtrace.rb
@@ -1,0 +1,29 @@
+require 'pry-byebug/helpers/navigation'
+
+module PryByebug
+  #
+  # Display the current stack
+  #
+  class BacktraceCommand < Pry::ClassCommand
+    include Helpers::Navigation
+
+    match 'backtrace'
+    group 'Byebug'
+
+    description 'Display the current stack.'
+
+    banner <<-BANNER
+      Usage: backtrace
+
+      Display the current stack.
+    BANNER
+
+    def process
+      PryByebug.check_file_context(target)
+
+      breakout_navigation :backtrace
+    end
+  end
+end
+
+Pry::Commands.add_command(PryByebug::BacktraceCommand)

--- a/test/commands/frames_test.rb
+++ b/test/commands/frames_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'stringio'
 
 #
 # Tests for pry-byebug frame commands.
@@ -57,6 +58,24 @@ class FramesTest < MiniTest::Spec
       it 'shows current line' do
         output.string.must_match(/=> \s*11: \s*end/)
       end
+    end
+  end
+
+  describe 'Backtrace command' do
+    let(:input) { InputTester.new('backtrace') }
+
+    before do
+      @stdout, @stderr = capture_subprocess_io do
+        redirect_pry_io(input) { load test_file('frames') }
+      end
+    end
+
+    it 'shows a backtrace' do
+      frames = @stdout.split("\n")
+
+      assert_match(/\A--> #0  FramesExample\.method_b at/, frames[0])
+      assert_match(/\A    #1  FramesExample\.method_a at/, frames[1])
+      assert_match(/\A    #2  <top \(required\)> at/, frames[2])
     end
   end
 end


### PR DESCRIPTION
This adds the `backtrace` command which prints the current stack. This goes hand-in-hand with `frame` because it also numbers the stack so you can easily jump to the frame you want. 