### PR TITLE
remove cli.rb to prevent loading of plugin

### DIFF
--- a/lib/pry-byebug/cli.rb
+++ b/lib/pry-byebug/cli.rb
@@ -1,3 +1,0 @@
-require 'pry-byebug/base'
-require 'pry-byebug/pry_ext'
-require 'pry-byebug/commands'


### PR DESCRIPTION
pry will load all cli.rb files from plugins, no matter when they are disabled or not

and loading cli.rb will load all extensions and fully loading the plugin
so `Pry.plugins['byebug'].disable!` does not work
neither does `Pry.config.should_load_plugins = false`

removing cli.rb fixes it


looks like it was introduced (https://github.com/deivid-rodriguez/pry-byebug/commits/77e1c046f89ae4b4dc255e6c5867415a20a78cec/lib/pry-debugger/cli.rb) to support pry-remote but that does not work much (#33)

Other pry plugins using cli.rb actually do something with the Pry::CLI which is not the case here. See https://github.com/pry/pry-exception_explorer/blob/540d7c9d139d6493083c3dc5c18315c1db100cc1/lib/pry-exception_explorer/cli.rb for an example.