### PR TITLE
Remove duplicated `require`, fix ctrl-d when loaded as pry plugin

### DIFF
--- a/lib/pry-byebug.rb
+++ b/lib/pry-byebug.rb
@@ -1,5 +1,2 @@
 require 'pry'
-require 'pry-byebug/base'
-require 'pry-byebug/pry_ext'
-require 'pry-byebug/commands'
-require 'pry-byebug/control_d_handler'
+require 'pry-byebug/cli'

--- a/lib/pry-byebug/cli.rb
+++ b/lib/pry-byebug/cli.rb
@@ -1,3 +1,4 @@
 require 'pry-byebug/base'
 require 'pry-byebug/pry_ext'
 require 'pry-byebug/commands'
+require 'pry-byebug/control_d_handler'


### PR DESCRIPTION
https://github.com/deivid-rodriguez/byebug/issues/144#issuecomment-259649650

> I use debbie gem (made from jazz_hands) and it doesn't require bry-byebug explicitly. So pry-byebug gets loaded with pry's plugin mechanism, and lib/pry-byebug/control_d_handler.rb is not required at all.