### PR TITLE
Get ready for 3.5.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ script:
   - bundle exec codeclimate-test-reporter || test true
 
 rvm:
-  - 2.1.10
   - 2.2.7
   - 2.3.4
   - 2.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Master (Unreleased)
 
+## 3.5.0 (2017-08-23)
+
+### Added
+
+* Byebug 9.1 support. As a result, Ruby 2.0 & Ruby 2.1 support has been dropped.
+  Pry-byebug no longer installs on these platforms.
+
 ## 3.4.3 (2017-08-22)
 
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    pry-byebug (3.4.3)
-      byebug (>= 9.0, < 9.1)
+    pry-byebug (3.5.0)
+      byebug (~> 9.1)
       pry (~> 0.10)
 
 GEM
@@ -10,7 +10,7 @@ GEM
   specs:
     addressable (2.4.0)
     ast (2.3.0)
-    byebug (9.0.6)
+    byebug (9.1.0)
     chandler (0.7.0)
       netrc
       octokit (>= 2.2.0)

--- a/lib/pry-byebug/version.rb
+++ b/lib/pry-byebug/version.rb
@@ -2,5 +2,5 @@
 # Main container module for Pry-Byebug functionality
 #
 module PryByebug
-  VERSION = '3.4.3'.freeze
+  VERSION = '3.5.0'.freeze
 end

--- a/pry-byebug.gemspec
+++ b/pry-byebug.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_path = 'lib'
 
   # Dependencies
-  gem.required_ruby_version = '>= 2.0.0'
+  gem.required_ruby_version = '>= 2.2.0'
   gem.add_runtime_dependency 'pry', '~> 0.10'
-  gem.add_runtime_dependency 'byebug', '>= 9.0', '< 9.1'
+  gem.add_runtime_dependency 'byebug', '~> 9.1'
 end


### PR DESCRIPTION
This PR gets ready for releasing 3.5.0, which will use byebug 9.1 and thus drop support for old rubies.