### PR TITLE
Allow other threads like pry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master (Unreleased)
 
+### Fixed
+
+* Allow other threads like Pry. (#142)
+
 ## 3.5.0 (2017-08-23)
 
 ### Added

--- a/lib/byebug/processors/pry_processor.rb
+++ b/lib/byebug/processors/pry_processor.rb
@@ -25,7 +25,7 @@ module Byebug
       return_value = nil
 
       command = catch(:breakout_nav) do # Throws from PryByebug::Commands
-        return_value = yield
+        return_value = allowing_other_threads { yield }
         {} # Nothing thrown == no navigational command
       end
 

--- a/test/examples/echo_thread.rb
+++ b/test/examples/echo_thread.rb
@@ -1,0 +1,12 @@
+require 'socket'
+
+client, server = Socket.pair(Socket::AF_UNIX, Socket::SOCK_STREAM)
+
+Thread.new do
+  while (line = server.readline)
+    server.write(line)
+  end
+end
+
+binding.pry
+client

--- a/test/thread_lock_test.rb
+++ b/test/thread_lock_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+require 'timeout'
+
+class ThreadLockTest < MiniTest::Spec
+  let(:output) { StringIO.new }
+  let(:input) { InputTester.new }
+
+  describe "when there's another thread" do
+    before do
+      input.add 'client.puts("Hello")'
+      input.add 'IO.select([client], [], [], 1) && client.readline'
+
+      redirect_pry_io(input, output) { load test_file('echo_thread') }
+    end
+
+    it "another thread isn't locked" do
+      assert_equal "=> \"Hello\\n\"\n", output.string.lines.last
+    end
+  end
+end


### PR DESCRIPTION
Thank you for creating awesome gem!

I often use this gem with capybara.
In capybara, generally test server is booted in other thread.
I noticed that `binding.pry` locks other thread if I install `pry-byebug` whereas it doesn't lock if I have `pry` only.

I found we can unlock by `Byebug.unlock` though,
I think it's good to follow Pry's default, in other words, I think we shouldn't change default behavior as far as possible.

What do you think?