### PR TITLE
Add SemVer badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build][TravisBadge]][TravisURL]
 [![Inline docs][InchCIBadge]][InchCIURL]
 [![Coverage][CoverageBadge]][CoverageURL]
+[![SemVer][SemVerBadge]][SemVerBadgeURL]
 
 Adds step-by-step debugging and stack navigation capabilities to [pry] using
 [byebug].
@@ -181,3 +182,5 @@ Patches and bug reports are welcome.
 [InchCIURL]: http://inch-ci.org/github/deivid-rodriguez/pry-byebug
 [CoverageBadge]: https://img.shields.io/codeclimate/coverage/github/deivid-rodriguez/pry-byebug.svg
 [CoverageURL]: https://codeclimate.com/github/deivid-rodriguez/pry-byebug
+[SemVerBadge]: https://api.dependabot.com/badges/compatibility_score?dependency-name=pry-byebug&package-manager=bundler&version-scheme=semver
+[SemVerBadgeURL]: https://dependabot.com/compatibility-score.html?dependency-name=pry-byebug&package-manager=bundler&version-scheme=semver


### PR DESCRIPTION
Would you be up for showing pry-byebug's SemVer compatibility in a badge on your readme? I've just added the ability to do that using data from Dependabot - what do you reckon?

Here's what the badge would look like, and where it will link to:

[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=pry-byebug&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=pry-byebug&package-manager=bundler&version-scheme=semver)

Any feedback super appreciated. Do you think we should have the logo in there or would it be cleaner without it, for example?