### PR TITLE
Replace Travis CI badge with Circle CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pry-byebug
 
 [![Version][VersionBadge]][VersionURL]
-[![Build][TravisBadge]][TravisURL]
+[![Build][CircleCIBadge]][CircleCIURL]
 [![Inline docs][InchCIBadge]][InchCIURL]
 [![Coverage][CoverageBadge]][CoverageURL]
 
@@ -177,8 +177,8 @@ Patches and bug reports are welcome.
 
 [VersionBadge]: https://badge.fury.io/rb/pry-byebug.svg
 [VersionURL]: http://badge.fury.io/rb/pry-byebug
-[TravisBadge]: https://secure.travis-ci.org/deivid-rodriguez/pry-byebug.svg
-[TravisURL]: http://travis-ci.org/deivid-rodriguez/pry-byebug
+[CircleCIBadge]: https://circleci.com/gh/deivid-rodriguez/pry-byebug/tree/master.svg?style=shield
+[CircleCIURL]: https://circleci.com/gh/deivid-rodriguez/pry-byebug/tree/master
 [InchCIBadge]: http://inch-ci.org/github/deivid-rodriguez/pry-byebug.svg?branch=master
 [InchCIURL]: http://inch-ci.org/github/deivid-rodriguez/pry-byebug
 [CoverageBadge]: https://img.shields.io/codeclimate/coverage/github/deivid-rodriguez/pry-byebug.svg


### PR DESCRIPTION
If I understand correctly, Circle CI is now being used.

I used the shields style, but there's also the option of using CircleCIs own style, compare:
![Circle CI Status](https://circleci.com/gh/deivid-rodriguez/pry-byebug/tree/master.svg?style=svg)
![Circle CI Status](https://circleci.com/gh/deivid-rodriguez/pry-byebug/tree/master.svg?style=shield)