### PR TITLE
Fix ruby 2.7 warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Master (Unreleased)
 
+### Fixed
+
+* use Binding#source_location instead of evaluating __FILE__ to avoid warnings
+  for Ruby >= 2.6 (#221).
+
 ## 3.7.0 (2019-02-21)
 
 * Byebug 11 compatibility, with ruby 2.6 support.

--- a/lib/pry-byebug/base.rb
+++ b/lib/pry-byebug/base.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "pry-byebug/helpers/location"
+
 #
 # Main container module for Pry-Byebug functionality
 #
@@ -13,7 +15,7 @@ module PryByebug
   # Checks that a target binding is in a local file context.
   #
   def file_context?(target)
-    file = target.eval("__FILE__")
+    file = Helpers::Location.current_file(target)
     file == Pry.eval_path || !Pry::Helpers::BaseHelpers.not_a_real_file?(file)
   end
 

--- a/lib/pry-byebug/commands/breakpoint.rb
+++ b/lib/pry-byebug/commands/breakpoint.rb
@@ -2,6 +2,7 @@
 
 require "pry/byebug/breakpoints"
 require "pry-byebug/helpers/breakpoints"
+require "pry-byebug/helpers/location"
 require "pry-byebug/helpers/multiline"
 
 module PryByebug
@@ -10,6 +11,7 @@ module PryByebug
   #
   class BreakCommand < Pry::ClassCommand
     include Helpers::Breakpoints
+    include Helpers::Location
     include Helpers::Multiline
 
     match "break"

--- a/lib/pry-byebug/commands/continue.rb
+++ b/lib/pry-byebug/commands/continue.rb
@@ -2,6 +2,7 @@
 
 require "pry-byebug/helpers/navigation"
 require "pry-byebug/helpers/breakpoints"
+require "pry-byebug/helpers/location"
 
 module PryByebug
   #
@@ -10,6 +11,7 @@ module PryByebug
   class ContinueCommand < Pry::ClassCommand
     include Helpers::Navigation
     include Helpers::Breakpoints
+    include Helpers::Location
 
     match "continue"
     group "Byebug"

--- a/lib/pry-byebug/helpers/breakpoints.rb
+++ b/lib/pry-byebug/helpers/breakpoints.rb
@@ -16,14 +16,6 @@ module PryByebug
       end
 
       #
-      # Current file in the target binding. Used as the default breakpoint
-      # location.
-      #
-      def current_file
-        target.eval("__FILE__")
-      end
-
-      #
       # Prints a message with bold font.
       #
       def bold_puts(msg)

--- a/lib/pry-byebug/helpers/location.rb
+++ b/lib/pry-byebug/helpers/location.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module PryByebug
+  module Helpers
+    #
+    # Compatibility helper to handle source location
+    #
+    module Location
+      module_function
+
+      #
+      # Current file in the target binding. Used as the default breakpoint
+      # location.
+      #
+      def current_file(source = target)
+        # Guard clause for Ruby >= 2.6 providing now Binding#source_location ...
+        return source.source_location[0] if source.respond_to?(:source_location)
+
+        # ... to avoid warning: 'eval may not return location in binding'
+        source.eval("__FILE__")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixed warning raised by latest ruby (__FILE__ in eval) in base.rb

Fixes #221.