### PR TITLE
Fix minitest 6 deprecations

### DIFF
--- a/test/commands/frames_test.rb
+++ b/test/commands/frames_test.rb
@@ -19,7 +19,7 @@ class FramesTest < MiniTest::Spec
     end
 
     it "shows current line" do
-      output.string.must_match(/=> \s*8: \s*method_b/)
+      _(output.string).must_match(/=> \s*8: \s*method_b/)
     end
   end
 
@@ -31,7 +31,7 @@ class FramesTest < MiniTest::Spec
     end
 
     it "shows current line" do
-      output.string.must_match(/=> \s*13: \s*end/)
+      _(output.string).must_match(/=> \s*13: \s*end/)
     end
   end
 
@@ -44,7 +44,7 @@ class FramesTest < MiniTest::Spec
       let(:input) { InputTester.new("frame 1", "frame 0") }
 
       it "shows current line" do
-        output.string.must_match(/=> \s*8: \s*method_b/)
+        _(output.string).must_match(/=> \s*8: \s*method_b/)
       end
     end
 
@@ -52,7 +52,7 @@ class FramesTest < MiniTest::Spec
       let(:input) { InputTester.new("frame 0") }
 
       it "shows current line" do
-        output.string.must_match(/=> \s*13: \s*end/)
+        _(output.string).must_match(/=> \s*13: \s*end/)
       end
     end
   end

--- a/test/processor_test.rb
+++ b/test/processor_test.rb
@@ -21,7 +21,7 @@ class ProcessorTest < Minitest::Spec
       after { clean_remove_const(:SteppingExample) }
 
       it "stops execution at the first line after binding.pry" do
-        output.string.must_match(/\=>  8:/)
+        _(output.string).must_match(/\=>  8:/)
       end
     end
 
@@ -33,7 +33,7 @@ class ProcessorTest < Minitest::Spec
       end
 
       it "stops execution at the first line after binding.pry" do
-        output.string.must_match(/\=>  9:/)
+        _(output.string).must_match(/\=>  9:/)
       end
     end
   end


### PR DESCRIPTION
Such as:

```
DEPRECATED: global use of must_match from <path_to_repo>/test/processor_test.rb:24. Use _(obj).must_match instead. This will fail in Minitest 6.
```