### PR TITLE
Fix flaky test failure

### DIFF
--- a/lib/pry/byebug/breakpoints.rb
+++ b/lib/pry/byebug/breakpoints.rb
@@ -88,7 +88,6 @@ class Pry
       #
       def delete(id)
         deleted =
-          ::Byebug.started? &&
           ::Byebug::Breakpoint.remove(id) &&
           breakpoints.delete(find_by_id(id))
 
@@ -100,7 +99,7 @@ class Pry
       #
       def delete_all
         @breakpoints = []
-        ::Byebug.breakpoints.clear if ::Byebug.started?
+        ::Byebug.breakpoints.clear
       end
 
       #

--- a/test/breakpoints_test.rb
+++ b/test/breakpoints_test.rb
@@ -31,6 +31,8 @@ class BreakpointsTestGeneral < MiniTest::Spec
 
     assert_equal "BreakpointsTest::Tester", bp.source
     assert_equal "instance_method", bp.pos
+
+    breakpoints_class.delete_all
   end
 
   def test_add_method_adds_class_method_breakpoint
@@ -39,5 +41,7 @@ class BreakpointsTestGeneral < MiniTest::Spec
 
     assert_equal "BreakpointsTest::Tester", bp.source
     assert_equal "class_method", bp.pos
+
+    breakpoints_class.delete_all
   end
 end


### PR DESCRIPTION
In particular

```
$ ruby -Itest:lib -rpry-byebug -e 'require "./test/breakpoints_test.rb"; require "./test/pry_ext_test.rb"' -- --seed=1 --verbose -n "/^(?:BreakpointsTestGeneral#(?:test_add_method_adds_class_method_breakpoint)|when disable-pry called#(?:test_0002_does not start byebug))$/"
Run options: --seed=1 --verbose -n "/^(?:BreakpointsTestGeneral#(?:test_add_method_adds_class_method_breakpoint)|when disable-pry called#(?:test_0002_does not start byebug))$/"

# Running:

BreakpointsTestGeneral#test_add_method_adds_class_method_breakpoint = 0.00 s = .
/home/deivid/Code/pry-byebug/test/examples/multiple.rb:5: warning: __FILE__ in eval may not return location in binding; use Binding#source_location instead
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/pry-0.12.2/lib/pry/commands/whereami.rb:40: warning: in `eval'
/home/deivid/Code/pry-byebug/test/examples/multiple.rb:5: warning: __LINE__ in eval may not return location in binding; use Binding#source_location instead
/home/deivid/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/pry-0.12.2/lib/pry/commands/whereami.rb:41: warning: in `eval'
when disable-pry called#test_0002_does not start byebug = 0.08 s = F

Failure:
when disable-pry called#test_0002_does not start byebug [/home/deivid/Code/pry-byebug/test/pry_ext_test.rb:22]:
Expected false to be truthy.
```

To fix it, I'm cleaning up breakpoints leaked by the breakpoints tests
preventing byebug to be "autostopped" because it has active breakpoints.

Clearing breakpoints through `Breakpoints.delete_all` was not enough
because the underlying byebug breakpoints were not being deleted unless
Byebug was already started, and Byebug is not started during the
execution of this unit test.

Normally I don't like making changes in lib just to fix a flaky test but
in this case I see no particular reason to do this check so I'll take
the risk and remove the conditions.