### PR TITLE
Rename '_pry_' to 'pry_instance'

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ your `~/.pryrc` file:
 ```ruby
 # Hit Enter to repeat last command
 Pry::Commands.command /^$/, "repeat last command" do
-  _pry_.run_command Pry.history.to_a.last
+  pry_instance.run_command Pry.history.to_a.last
 end
 ```
 


### PR DESCRIPTION
Hello, I hope you are doing well.

I noticed that my .pryrc file was raising this warning:

```
"warning: _pry_ is deprecated, use pry_instance instead"
```

If you are curious about the content of the file:

```ruby
# frozen_string_literal: true

if defined?(PryByebug)
  Pry.commands.alias_command 'c', 'continue'
  Pry.commands.alias_command 's', 'step'
  Pry.commands.alias_command 'n', 'next'
  Pry.commands.alias_command 'f', 'finish'

  # Hit Enter to repeat last command
  Pry::Commands.command(/^$/, 'repeat last command') do
    _pry_.run_command Pry.history.to_a.last
  end
end
```

I took a look at the pry gem and found the PR that added the warning: https://github.com/pry/pry/pull/1989

So, this simple PR aims to update the Readme by replacing the deprecated method.