### PR TITLE
Require gem properly if it's loaded as Pry's plugin

### DIFF
--- a/lib/pry-byebug/cli.rb
+++ b/lib/pry-byebug/cli.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "pry-byebug" if defined? Pry # Make Pry's plugin autoload properly mark this gem
 require "pry-byebug/base"
 require "pry-byebug/pry_ext"
 require "pry-byebug/commands"


### PR DESCRIPTION
A small change for convenience.

Often `pry-byebug` is getting loaded by Pry's plugin auto-detection: https://github.com/pry/pry/blob/v0.13.1/lib/pry/plugins.rb#L49

In this case, all the `pry-byebug` functionality is loaded, but it's not registered as a `require`d which may lead to confusion.
Before:
```
2.7.2 :001 > require 'pry'
 => true
2.7.2 :002 > require 'pry-byebug'
 => true # This should not be "true", this require adds nothing
```
After:
```
2.7.2 :001 > require 'pry'
 => true
2.7.2 :002 > require 'pry-byebug'
 => false
```