### PR TITLE
Make the `pry-byebug` compatible with `pry-remote` gem

### DIFF
--- a/lib/byebug/processors/pry_remote_processor.rb
+++ b/lib/byebug/processors/pry_remote_processor.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "byebug/core"
+
+module Byebug
+  #
+  # Extends the PryProcessor to make it work with Pry-Remote
+  #
+  class PryRemoteProcessor < PryProcessor
+    class PryRemoteInterface
+      attr_reader :output, :input
+
+      def initialize(input, output)
+        @input = input
+        @output = output
+      end
+    end
+
+    def self.start(input:, output:, **)
+      super()
+
+      Context.interface = PryRemoteInterface.new(input, output)
+      Byebug.current_context.step_out(5, true)
+    end
+
+    def initialize(context, *)
+      @interface = Context.interface
+
+      super
+    end
+
+    def resume_pry
+      new_binding = frame._binding
+
+      run do
+        if defined?(@pry) && @pry
+          @pry.repl(new_binding)
+        else
+          @pry = Pry.start_without_pry_byebug(new_binding, input: @interface.input, output: @interface.output)
+        end
+      end
+    end
+  end
+end

--- a/lib/pry-byebug/base.rb
+++ b/lib/pry-byebug/base.rb
@@ -7,7 +7,9 @@ require "pry-byebug/helpers/location"
 #
 module PryByebug
   # Reference to currently running pry-remote server. Used by the processor.
-  attr_accessor :current_remote_server
+  class << self
+    attr_accessor :current_remote_server
+  end
 
   module_function
 

--- a/lib/pry-byebug/pry_ext.rb
+++ b/lib/pry-byebug/pry_ext.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 require "byebug/processors/pry_processor"
+require "byebug/processors/pry_remote_processor"
 
 class << Pry
   alias start_without_pry_byebug start
 
   def start_with_pry_byebug(target = TOPLEVEL_BINDING, options = {})
-    if target.is_a?(Binding) && PryByebug.file_context?(target)
-      Byebug::PryProcessor.start unless ENV["DISABLE_PRY"]
+    if target.is_a?(Binding) && PryByebug.file_context?(target) && !ENV["DISABLE_PRY"]
+      PryByebug.current_remote_server ? Byebug::PryRemoteProcessor.start(options) : Byebug::PryProcessor.start
     else
       # No need for the tracer unless we have a file context to step through
       start_without_pry_byebug(target, options)


### PR DESCRIPTION
I couldn't find a better way to pass the `pry-remote` input and output to pry instance without changing a lot of the byebug processors, This is why I had to use the `Context.interface`.

Fixes #33