### PR TITLE
Make sure to stop byebug if eval raised

### DIFF
--- a/lib/pry-byebug/pry_ext.rb
+++ b/lib/pry-byebug/pry_ext.rb
@@ -16,3 +16,16 @@ class << Pry
 
   alias start start_with_pry_byebug
 end
+
+class Pry
+  alias eval_without_pry_byebug eval
+
+  def eval_with_pry_byebug(line, options = {})
+    eval_without_pry_byebug(line, options)
+  rescue Exception
+    ::Byebug.stop if ::Byebug.stoppable?
+    raise
+  end
+
+  alias eval eval_with_pry_byebug
+end


### PR DESCRIPTION
When I put a pry in a loop, it's frequent that when i'm done, I just use `!!!` to raise an exception which ends my current rails query.
Since I start using pry-byebug, I noticed that doing so made the whole interpreter like 8x slower. 

Investigation made me learn that if an exception is raised using commands, this bypasses the usual mechanism that stops byebug, leading to a slow interpretter.
This fixes that behavior by detecting that an exception is propagating out of eval and stopping byebug.

I would assume that situation also happened when someone used the raise-up command.

I don't know enough about Pry, but I would guess this exact fix may be wrong when dealing with nested pry. So there may be some extra-checks needed to make sure we are not nested, but I don't know how to do that.

