### PR TITLE
Freeze RuboCop configuration to 0.93.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,41 +1,3767 @@
 AllCops:
+  DisabledByDefault: true
   DisplayCopNames: true
   DisplayStyleGuide: true
 
   TargetRubyVersion: 2.4
 
-Lint/Debugger:
-  Exclude:
-    - test/examples/*.rb
+# Department 'Bundler' (4):
+Bundler/DuplicatedGem:
+  Description: Checks for duplicate gem entries in Gemfile.
+  Enabled: true
+  VersionAdded: '0.46'
+  Include:
+  - "**/*.gemfile"
+  - "**/Gemfile"
+  - "**/gems.rb"
 
-Metrics:
+Bundler/GemComment:
+  Description: Add a comment describing each gem.
   Enabled: false
+  VersionAdded: '0.59'
+  VersionChanged: '0.85'
+  Include:
+  - "**/*.gemfile"
+  - "**/Gemfile"
+  - "**/gems.rb"
+  IgnoredGems: []
+  OnlyFor: []
+
+# Supports --auto-correct
+Bundler/InsecureProtocolSource:
+  Description: The source `:gemcutter`, `:rubygems` and `:rubyforge` are deprecated
+    because HTTP requests are insecure. Please change your source to 'https://rubygems.org'
+    if possible, or 'http://rubygems.org' if not.
+  Enabled: true
+  VersionAdded: '0.50'
+  Include:
+  - "**/*.gemfile"
+  - "**/Gemfile"
+  - "**/gems.rb"
+
+# Supports --auto-correct
+Bundler/OrderedGems:
+  Description: Gems within groups in the Gemfile should be alphabetically sorted.
+  Enabled: true
+  VersionAdded: '0.46'
+  VersionChanged: '0.47'
+  TreatCommentsAsGroupSeparators: true
+  ConsiderPunctuation: false
+  Include:
+  - "**/*.gemfile"
+  - "**/Gemfile"
+  - "**/gems.rb"
+
+# Department 'Gemspec' (4):
+Gemspec/DuplicatedAssignment:
+  Description: An attribute assignment method calls should be listed only once in a
+    gemspec.
+  Enabled: true
+  VersionAdded: '0.52'
+  Include:
+  - "**/*.gemspec"
+
+# Supports --auto-correct
+Gemspec/OrderedDependencies:
+  Description: Dependencies in the gemspec should be alphabetically sorted.
+  Enabled: true
+  VersionAdded: '0.51'
+  TreatCommentsAsGroupSeparators: true
+  ConsiderPunctuation: false
+  Include:
+  - "**/*.gemspec"
+
+Gemspec/RequiredRubyVersion:
+  Description: Checks that `required_ruby_version` of gemspec is specified and equal
+    to `TargetRubyVersion` of .rubocop.yml.
+  Enabled: true
+  VersionAdded: '0.52'
+  VersionChanged: '0.89'
+  Include:
+  - "**/*.gemspec"
+
+Gemspec/RubyVersionGlobalsUsage:
+  Description: Checks usage of RUBY_VERSION in gemspec.
+  StyleGuide: "#no-ruby-version-in-the-gemspec"
+  Enabled: true
+  VersionAdded: '0.72'
+  Include:
+  - "**/*.gemspec"
+
+# Department 'Layout' (92):
+# Supports --auto-correct
+Layout/AccessModifierIndentation:
+  Description: Check indentation of private/protected visibility modifiers.
+  StyleGuide: "#indent-public-private-protected"
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: indent
+  SupportedStyles:
+  - outdent
+  - indent
+  IndentationWidth:
+
+# Supports --auto-correct
+Layout/ArgumentAlignment:
+  Description: Align the arguments of a method call if they span more than one line.
+  StyleGuide: "#no-double-indent"
+  Enabled: true
+  VersionAdded: '0.68'
+  VersionChanged: '0.77'
+  EnforcedStyle: with_first_argument
+  SupportedStyles:
+  - with_first_argument
+  - with_fixed_indentation
+  IndentationWidth:
+
+# Supports --auto-correct
+Layout/ArrayAlignment:
+  Description: Align the elements of an array literal if they span more than one line.
+  StyleGuide: "#no-double-indent"
+  Enabled: true
+  VersionAdded: '0.49'
+  VersionChanged: '0.77'
+  EnforcedStyle: with_first_element
+  SupportedStyles:
+  - with_first_element
+  - with_fixed_indentation
+  IndentationWidth:
+
+# Supports --auto-correct
+Layout/AssignmentIndentation:
+  Description: Checks the indentation of the first line of the right-hand-side of a
+    multi-line assignment.
+  Enabled: true
+  VersionAdded: '0.49'
+  VersionChanged: '0.77'
+  IndentationWidth:
+
+# Supports --auto-correct
+Layout/BeginEndAlignment:
+  Description: Align ends corresponding to begins correctly.
+  Enabled: true
+  VersionAdded: '0.91'
+  EnforcedStyleAlignWith: start_of_line
+  SupportedStylesAlignWith:
+  - start_of_line
+  - begin
+  Severity: warning
+
+# Supports --auto-correct
+Layout/BlockAlignment:
+  Description: Align block ends correctly.
+  Enabled: true
+  VersionAdded: '0.53'
+  EnforcedStyleAlignWith: either
+  SupportedStylesAlignWith:
+  - either
+  - start_of_block
+  - start_of_line
+
+# Supports --auto-correct
+Layout/BlockEndNewline:
+  Description: Put end statement of multiline block on its own line.
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/CaseIndentation:
+  Description: Indentation of when in a case/when/[else/]end.
+  StyleGuide: "#indent-when-to-case"
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: case
+  SupportedStyles:
+  - case
+  - end
+  IndentOneStep: false
+  IndentationWidth:
+
+# Supports --auto-correct
+Layout/ClassStructure:
+  Description: Enforces a configured order of definitions within a class body.
+  StyleGuide: "#consistent-classes"
+  Enabled: false
+  VersionAdded: '0.52'
+  Categories:
+    module_inclusion:
+    - include
+    - prepend
+    - extend
+  ExpectedOrder:
+  - module_inclusion
+  - constants
+  - public_class_methods
+  - initializer
+  - public_methods
+  - protected_methods
+  - private_methods
+
+# Supports --auto-correct
+Layout/ClosingHeredocIndentation:
+  Description: Checks the indentation of here document closings.
+  Enabled: true
+  VersionAdded: '0.57'
+
+# Supports --auto-correct
+Layout/ClosingParenthesisIndentation:
+  Description: Checks the indentation of hanging closing parentheses.
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/CommentIndentation:
+  Description: Indentation of comments.
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/ConditionPosition:
+  Description: Checks for condition placed in a confusing position relative to the keyword.
+  StyleGuide: "#same-line-condition"
+  Enabled: true
+  VersionAdded: '0.53'
+  VersionChanged: '0.83'
+
+# Supports --auto-correct
+Layout/DefEndAlignment:
+  Description: Align ends corresponding to defs correctly.
+  Enabled: true
+  VersionAdded: '0.53'
+  EnforcedStyleAlignWith: start_of_line
+  SupportedStylesAlignWith:
+  - start_of_line
+  - def
+  Severity: warning
+
+# Supports --auto-correct
+Layout/DotPosition:
+  Description: Checks the position of the dot in multi-line method calls.
+  StyleGuide: "#consistent-multi-line-chains"
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: leading
+  SupportedStyles:
+  - leading
+  - trailing
+
+# Supports --auto-correct
+Layout/ElseAlignment:
+  Description: Align elses and elsifs correctly.
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/EmptyComment:
+  Description: Checks empty comment.
+  Enabled: true
+  VersionAdded: '0.53'
+  AllowBorderComment: true
+  AllowMarginComment: true
+
+# Supports --auto-correct
+Layout/EmptyLineAfterGuardClause:
+  Description: Add empty line after guard clause.
+  Enabled: true
+  VersionAdded: '0.56'
+  VersionChanged: '0.59'
+
+# Supports --auto-correct
+Layout/EmptyLineAfterMagicComment:
+  Description: Add an empty line after magic comments to separate them from code.
+  StyleGuide: "#separate-magic-comments-from-code"
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/EmptyLineAfterMultilineCondition:
+  Description: Enforces empty line after multiline condition.
+  Enabled: false
+  VersionAdded: '0.90'
+  Reference:
+  - https://github.com/airbnb/ruby#multiline-if-newline
+
+# Supports --auto-correct
+Layout/EmptyLineBetweenDefs:
+  Description: Use empty lines between defs.
+  StyleGuide: "#empty-lines-between-methods"
+  Enabled: true
+  VersionAdded: '0.49'
+  AllowAdjacentOneLineDefs: false
+  NumberOfEmptyLines: 1
+
+# Supports --auto-correct
+Layout/EmptyLines:
+  Description: Don't use several empty lines in a row.
+  StyleGuide: "#two-or-more-empty-lines"
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/EmptyLinesAroundAccessModifier:
+  Description: Keep blank lines around access modifiers.
+  StyleGuide: "#empty-lines-around-access-modifier"
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: around
+  SupportedStyles:
+  - around
+  - only_before
+  Reference:
+  - https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
+
+# Supports --auto-correct
+Layout/EmptyLinesAroundArguments:
+  Description: Keeps track of empty lines around method arguments.
+  Enabled: true
+  VersionAdded: '0.52'
+
+# Supports --auto-correct
+Layout/EmptyLinesAroundAttributeAccessor:
+  Description: Keep blank lines around attribute accessors.
+  StyleGuide: "#empty-lines-around-attribute-accessor"
+  Enabled: true
+  VersionAdded: '0.83'
+  VersionChanged: '0.84'
+  AllowAliasSyntax: true
+  AllowedMethods:
+  - alias_method
+  - public
+  - protected
+  - private
+
+# Supports --auto-correct
+Layout/EmptyLinesAroundBeginBody:
+  Description: Keeps track of empty lines around begin-end bodies.
+  StyleGuide: "#empty-lines-around-bodies"
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/EmptyLinesAroundBlockBody:
+  Description: Keeps track of empty lines around block bodies.
+  StyleGuide: "#empty-lines-around-bodies"
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - no_empty_lines
+
+# Supports --auto-correct
+Layout/EmptyLinesAroundClassBody:
+  Description: Keeps track of empty lines around class bodies.
+  StyleGuide: "#empty-lines-around-bodies"
+  Enabled: true
+  VersionAdded: '0.49'
+  VersionChanged: '0.53'
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - empty_lines_except_namespace
+  - empty_lines_special
+  - no_empty_lines
+  - beginning_only
+  - ending_only
+
+# Supports --auto-correct
+Layout/EmptyLinesAroundExceptionHandlingKeywords:
+  Description: Keeps track of empty lines around exception handling keywords.
+  StyleGuide: "#empty-lines-around-bodies"
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/EmptyLinesAroundMethodBody:
+  Description: Keeps track of empty lines around method bodies.
+  StyleGuide: "#empty-lines-around-bodies"
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/EmptyLinesAroundModuleBody:
+  Description: Keeps track of empty lines around module bodies.
+  StyleGuide: "#empty-lines-around-bodies"
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - empty_lines_except_namespace
+  - empty_lines_special
+  - no_empty_lines
+
+# Supports --auto-correct
+Layout/EndAlignment:
+  Description: Align ends correctly.
+  Enabled: true
+  VersionAdded: '0.53'
+  EnforcedStyleAlignWith: keyword
+  SupportedStylesAlignWith:
+  - keyword
+  - variable
+  - start_of_line
+  Severity: warning
+
+Layout/EndOfLine:
+  Description: Use Unix-style line endings.
+  StyleGuide: "#crlf"
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: native
+  SupportedStyles:
+  - native
+  - lf
+  - crlf
+
+# Supports --auto-correct
+Layout/ExtraSpacing:
+  Description: Do not use unnecessary spacing.
+  Enabled: true
+  VersionAdded: '0.49'
+  AllowForAlignment: false
+  AllowBeforeTrailingComments: false
+  ForceEqualSignAlignment: false
+
+# Supports --auto-correct
+Layout/FirstArgumentIndentation:
+  Description: Checks the indentation of the first argument in a method call.
+  Enabled: true
+  VersionAdded: '0.68'
+  VersionChanged: '0.77'
+  EnforcedStyle: special_for_inner_method_call_in_parentheses
+  SupportedStyles:
+  - consistent
+  - consistent_relative_to_receiver
+  - special_for_inner_method_call
+  - special_for_inner_method_call_in_parentheses
+  IndentationWidth:
+
+# Supports --auto-correct
+Layout/FirstArrayElementIndentation:
+  Description: Checks the indentation of the first element in an array literal.
+  Enabled: true
+  VersionAdded: '0.68'
+  VersionChanged: '0.77'
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+  - special_inside_parentheses
+  - consistent
+  - align_brackets
+  IndentationWidth:
+
+# Supports --auto-correct
+Layout/FirstArrayElementLineBreak:
+  Description: Checks for a line break before the first element in a multi-line array.
+  Enabled: false
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/FirstHashElementIndentation:
+  Description: Checks the indentation of the first key in a hash literal.
+  Enabled: true
+  VersionAdded: '0.68'
+  VersionChanged: '0.77'
+  EnforcedStyle: special_inside_parentheses
+  SupportedStyles:
+  - special_inside_parentheses
+  - consistent
+  - align_braces
+  IndentationWidth:
+
+# Supports --auto-correct
+Layout/FirstHashElementLineBreak:
+  Description: Checks for a line break before the first element in a multi-line hash.
+  Enabled: false
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/FirstMethodArgumentLineBreak:
+  Description: Checks for a line break before the first argument in a multi-line method
+    call.
+  Enabled: false
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/FirstMethodParameterLineBreak:
+  Description: Checks for a line break before the first parameter in a multi-line method
+    parameter definition.
+  Enabled: false
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/FirstParameterIndentation:
+  Description: Checks the indentation of the first parameter in a method definition.
+  Enabled: true
+  VersionAdded: '0.49'
+  VersionChanged: '0.77'
+  EnforcedStyle: consistent
+  SupportedStyles:
+  - consistent
+  - align_parentheses
+  IndentationWidth:
+
+# Supports --auto-correct
+Layout/HashAlignment:
+  Description: Align the elements of a hash literal if they span more than one line.
+  Enabled: true
+  AllowMultipleStyles: true
+  VersionAdded: '0.49'
+  VersionChanged: '0.77'
+  EnforcedHashRocketStyle: key
+  SupportedHashRocketStyles:
+  - key
+  - separator
+  - table
+  EnforcedColonStyle: key
+  SupportedColonStyles:
+  - key
+  - separator
+  - table
+  EnforcedLastArgumentHashStyle: always_inspect
+  SupportedLastArgumentHashStyles:
+  - always_inspect
+  - always_ignore
+  - ignore_implicit
+  - ignore_explicit
+
+# Supports --auto-correct
+Layout/HeredocArgumentClosingParenthesis:
+  Description: Checks for the placement of the closing parenthesis in a method call
+    that passes a HEREDOC string as an argument.
+  Enabled: false
+  StyleGuide: "#heredoc-argument-closing-parentheses"
+  VersionAdded: '0.68'
+
+# Supports --auto-correct
+Layout/HeredocIndentation:
+  Description: This cop checks the indentation of the here document bodies.
+  StyleGuide: "#squiggly-heredocs"
+  Enabled: true
+  VersionAdded: '0.49'
+  VersionChanged: '0.85'
+
+# Supports --auto-correct
+Layout/IndentationConsistency:
+  Description: Keep indentation straight.
+  StyleGuide: "#spaces-indentation"
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: normal
+  SupportedStyles:
+  - normal
+  - indented_internal_methods
+  Reference:
+  - https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions
+
+# Supports --auto-correct
+Layout/IndentationStyle:
+  Description: Consistent indentation either with tabs only or spaces only.
+  StyleGuide: "#spaces-indentation"
+  Enabled: true
+  VersionAdded: '0.49'
+  VersionChanged: '0.82'
+  IndentationWidth:
+  EnforcedStyle: spaces
+  SupportedStyles:
+  - spaces
+  - tabs
+
+# Supports --auto-correct
+Layout/IndentationWidth:
+  Description: Use 2 spaces for indentation.
+  StyleGuide: "#spaces-indentation"
+  Enabled: true
+  VersionAdded: '0.49'
+  Width: 2
+  IgnoredPatterns: []
+
+# Supports --auto-correct
+Layout/InitialIndentation:
+  Description: Checks the indentation of the first non-blank non-comment line in a file.
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/LeadingCommentSpace:
+  Description: Comments should start with a space.
+  StyleGuide: "#hash-space"
+  Enabled: true
+  VersionAdded: '0.49'
+  VersionChanged: '0.73'
+  AllowDoxygenCommentStyle: false
+  AllowGemfileRubyComment: false
+
+# Supports --auto-correct
+Layout/LeadingEmptyLines:
+  Description: Check for unnecessary blank lines at the beginning of a file.
+  Enabled: true
+  VersionAdded: '0.57'
+  VersionChanged: '0.77'
+
+# Supports --auto-correct
+Layout/MultilineArrayBraceLayout:
+  Description: Checks that the closing brace in an array literal is either on the same
+    line as the last array element, or a new line.
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+  - symmetrical
+  - new_line
+  - same_line
+
+# Supports --auto-correct
+Layout/MultilineArrayLineBreaks:
+  Description: Checks that each item in a multi-line array literal starts on a separate
+    line.
+  Enabled: false
+  VersionAdded: '0.67'
+
+# Supports --auto-correct
+Layout/MultilineAssignmentLayout:
+  Description: Check for a newline after the assignment operator in multi-line assignments.
+  StyleGuide: "#indent-conditional-assignment"
+  Enabled: false
+  VersionAdded: '0.49'
+  SupportedTypes:
+  - block
+  - case
+  - class
+  - if
+  - kwbegin
+  - module
+  EnforcedStyle: new_line
+  SupportedStyles:
+  - same_line
+  - new_line
+
+# Supports --auto-correct
+Layout/MultilineBlockLayout:
+  Description: Ensures newlines after multiline block do statements.
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/MultilineHashBraceLayout:
+  Description: Checks that the closing brace in a hash literal is either on the same
+    line as the last hash element, or a new line.
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+  - symmetrical
+  - new_line
+  - same_line
+
+# Supports --auto-correct
+Layout/MultilineHashKeyLineBreaks:
+  Description: Checks that each item in a multi-line hash literal starts on a separate
+    line.
+  Enabled: false
+  VersionAdded: '0.67'
+
+# Supports --auto-correct
+Layout/MultilineMethodArgumentLineBreaks:
+  Description: Checks that each argument in a multi-line method call starts on a separate
+    line.
+  Enabled: false
+  VersionAdded: '0.67'
+
+# Supports --auto-correct
+Layout/MultilineMethodCallBraceLayout:
+  Description: Checks that the closing brace in a method call is either on the same
+    line as the last method argument, or a new line.
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+  - symmetrical
+  - new_line
+  - same_line
+
+# Supports --auto-correct
+Layout/MultilineMethodCallIndentation:
+  Description: Checks indentation of method calls with the dot operator that span more
+    than one line.
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: aligned
+  SupportedStyles:
+  - aligned
+  - indented
+  - indented_relative_to_receiver
+  IndentationWidth:
+
+# Supports --auto-correct
+Layout/MultilineMethodDefinitionBraceLayout:
+  Description: Checks that the closing brace in a method definition is either on the
+    same line as the last method parameter, or a new line.
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+  - symmetrical
+  - new_line
+  - same_line
+
+# Supports --auto-correct
+Layout/MultilineOperationIndentation:
+  Description: Checks indentation of binary operations that span more than one line.
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: aligned
+  SupportedStyles:
+  - aligned
+  - indented
+  IndentationWidth:
+
+# Supports --auto-correct
+Layout/ParameterAlignment:
+  Description: Align the parameters of a method definition if they span more than one
+    line.
+  StyleGuide: "#no-double-indent"
+  Enabled: true
+  VersionAdded: '0.49'
+  VersionChanged: '0.77'
+  EnforcedStyle: with_first_parameter
+  SupportedStyles:
+  - with_first_parameter
+  - with_fixed_indentation
+  IndentationWidth:
+
+# Supports --auto-correct
+Layout/RescueEnsureAlignment:
+  Description: Align rescues and ensures correctly.
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/SpaceAfterColon:
+  Description: Use spaces after colons.
+  StyleGuide: "#spaces-operators"
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/SpaceAfterComma:
+  Description: Use spaces after commas.
+  StyleGuide: "#spaces-operators"
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/SpaceAfterMethodName:
+  Description: Do not put a space between a method name and the opening parenthesis
+    in a method definition.
+  StyleGuide: "#parens-no-spaces"
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/SpaceAfterNot:
+  Description: Tracks redundant space after the ! operator.
+  StyleGuide: "#no-space-bang"
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/SpaceAfterSemicolon:
+  Description: Use spaces after semicolons.
+  StyleGuide: "#spaces-operators"
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/SpaceAroundBlockParameters:
+  Description: Checks the spacing inside and after block parameters pipes.
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyleInsidePipes: no_space
+  SupportedStylesInsidePipes:
+  - space
+  - no_space
+
+# Supports --auto-correct
+Layout/SpaceAroundEqualsInParameterDefault:
+  Description: Checks that the equals signs in parameter default assignments have or
+    don't have surrounding space de on configuration.
+  StyleGuide: "#spaces-around-equals"
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: space
+  SupportedStyles:
+  - space
+  - no_space
+
+# Supports --auto-correct
+Layout/SpaceAroundKeyword:
+  Description: Use a space around keywords if appropriate.
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/SpaceAroundMethodCallOperator:
+  Description: Checks method call operators to not have spaces around them.
+  Enabled: true
+  VersionAdded: '0.82'
+
+# Supports --auto-correct
+Layout/SpaceAroundOperators:
+  Description: Use a single space around operators.
+  StyleGuide: "#spaces-operators"
+  Enabled: true
+  VersionAdded: '0.49'
+  AllowForAlignment: true
+  EnforcedStyleForExponentOperator: no_space
+  SupportedStylesForExponentOperator:
+  - space
+  - no_space
+
+# Supports --auto-correct
+Layout/SpaceBeforeBlockBraces:
+  Description: Checks that the left block brace has or doesn't have space before it.
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: space
+  SupportedStyles:
+  - space
+  - no_space
+  EnforcedStyleForEmptyBraces: space
+  SupportedStylesForEmptyBraces:
+  - space
+  - no_space
+  VersionChanged: 0.52.1
+
+# Supports --auto-correct
+Layout/SpaceBeforeComma:
+  Description: No spaces before commas.
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/SpaceBeforeComment:
+  Description: Checks for missing space between code and a comment on the same line.
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/SpaceBeforeFirstArg:
+  Description: Checks that exactly one space is used between a method name and the first
+    argument for method calls without parentheses.
+  Enabled: true
+  VersionAdded: '0.49'
+  AllowForAlignment: true
+
+# Supports --auto-correct
+Layout/SpaceBeforeSemicolon:
+  Description: No spaces before semicolons.
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/SpaceInLambdaLiteral:
+  Description: Checks for spaces in lambda literals.
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: require_no_space
+  SupportedStyles:
+  - require_no_space
+  - require_space
+
+# Supports --auto-correct
+Layout/SpaceInsideArrayLiteralBrackets:
+  Description: Checks the spacing inside array literal brackets.
+  Enabled: true
+  VersionAdded: '0.52'
+  EnforcedStyle: no_space
+  SupportedStyles:
+  - space
+  - no_space
+  - compact
+  EnforcedStyleForEmptyBrackets: no_space
+  SupportedStylesForEmptyBrackets:
+  - space
+  - no_space
+
+# Supports --auto-correct
+Layout/SpaceInsideArrayPercentLiteral:
+  Description: No unnecessary additional spaces between elements in %i/%w literals.
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/SpaceInsideBlockBraces:
+  Description: Checks that block braces have or don't have surrounding space. For blocks
+    taking parameters, checks that the left brace has or doesn't have trailing space.
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: space
+  SupportedStyles:
+  - space
+  - no_space
+  EnforcedStyleForEmptyBraces: no_space
+  SupportedStylesForEmptyBraces:
+  - space
+  - no_space
+  SpaceBeforeBlockParameters: true
+
+# Supports --auto-correct
+Layout/SpaceInsideHashLiteralBraces:
+  Description: Use spaces inside hash literal braces - or don't.
+  StyleGuide: "#spaces-braces"
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: space
+  SupportedStyles:
+  - space
+  - no_space
+  - compact
+  EnforcedStyleForEmptyBraces: no_space
+  SupportedStylesForEmptyBraces:
+  - space
+  - no_space
+
+# Supports --auto-correct
+Layout/SpaceInsideParens:
+  Description: No spaces after ( or before ).
+  StyleGuide: "#spaces-braces"
+  Enabled: true
+  VersionAdded: '0.49'
+  VersionChanged: '0.55'
+  EnforcedStyle: no_space
+  SupportedStyles:
+  - space
+  - no_space
+
+# Supports --auto-correct
+Layout/SpaceInsidePercentLiteralDelimiters:
+  Description: No unnecessary spaces inside delimiters of %i/%w/%x literals.
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/SpaceInsideRangeLiteral:
+  Description: No spaces inside range literals.
+  StyleGuide: "#no-space-inside-range-literals"
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Layout/SpaceInsideReferenceBrackets:
+  Description: Checks the spacing inside referential brackets.
+  Enabled: true
+  VersionAdded: '0.52'
+  VersionChanged: '0.53'
+  EnforcedStyle: no_space
+  SupportedStyles:
+  - space
+  - no_space
+  EnforcedStyleForEmptyBrackets: no_space
+  SupportedStylesForEmptyBrackets:
+  - space
+  - no_space
+
+# Supports --auto-correct
+Layout/SpaceInsideStringInterpolation:
+  Description: Checks for padding/surrounding spaces inside string interpolation.
+  StyleGuide: "#string-interpolation"
+  Enabled: true
+  VersionAdded: '0.49'
+  EnforcedStyle: no_space
+  SupportedStyles:
+  - space
+  - no_space
+
+# Supports --auto-correct
+Layout/TrailingEmptyLines:
+  Description: Checks trailing blank lines and final newline.
+  StyleGuide: "#newline-eof"
+  Enabled: true
+  VersionAdded: '0.49'
+  VersionChanged: '0.77'
+  EnforcedStyle: final_newline
+  SupportedStyles:
+  - final_newline
+  - final_blank_line
+
+# Supports --auto-correct
+Layout/TrailingWhitespace:
+  Description: Avoid trailing whitespace.
+  StyleGuide: "#no-trailing-whitespace"
+  Enabled: true
+  VersionAdded: '0.49'
+  VersionChanged: '0.83'
+  AllowInHeredoc: true
+
+# Department 'Lint' (104):
+Lint/AmbiguousBlockAssociation:
+  Description: Checks for ambiguous block association with method when param passed
+    without parentheses.
+  StyleGuide: "#syntax"
+  Enabled: true
+  VersionAdded: '0.48'
+
+# Supports --auto-correct
+Lint/AmbiguousOperator:
+  Description: Checks for ambiguous operators in the first argument of a method invocation
+    without parentheses.
+  StyleGuide: "#method-invocation-parens"
+  Enabled: true
+  VersionAdded: '0.17'
+  VersionChanged: '0.83'
+
+# Supports --auto-correct
+Lint/AmbiguousRegexpLiteral:
+  Description: Checks for ambiguous regexp literals in the first argument of a method
+    invocation without parentheses.
+  Enabled: true
+  VersionAdded: '0.17'
+  VersionChanged: '0.83'
+
+Lint/AssignmentInCondition:
+  Description: Don't use assignment in conditions.
+  StyleGuide: "#safe-assignment-in-condition"
+  Enabled: true
+  VersionAdded: '0.9'
+  AllowSafeAssignment: true
+
+# Supports --auto-correct
+Lint/BigDecimalNew:
+  Description: "`BigDecimal.new()` is deprecated. Use `BigDecimal()` instead."
+  Enabled: true
+  VersionAdded: '0.53'
+
+Lint/BinaryOperatorWithIdenticalOperands:
+  Description: This cop checks for places where binary operator has identical operands.
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.89'
+
+# Supports --auto-correct
+Lint/BooleanSymbol:
+  Description: Check for `:true` and `:false` symbols.
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.50'
+  VersionChanged: '0.83'
+
+Lint/CircularArgumentReference:
+  Description: Default values in optional keyword arguments and optional ordinal arguments
+    should not refer back to the name of the argument.
+  Enabled: true
+  VersionAdded: '0.33'
+
+Lint/ConstantDefinitionInBlock:
+  Description: Do not define constants within a block.
+  StyleGuide: "#no-constant-definition-in-block"
+  Enabled: true
+  VersionAdded: '0.91'
+
+Lint/ConstantResolution:
+  Description: Check that constants are fully qualified with `::`.
+  Enabled: false
+  VersionAdded: '0.86'
+  Only: []
+  Ignore: []
+
+Lint/Debugger:
+  Description: Check for debugger calls.
+  Enabled: true
+  VersionAdded: '0.14'
+  VersionChanged: '0.49'
+  Exclude:
+  - test/examples/*.rb
+
+# Supports --auto-correct
+Lint/DeprecatedClassMethods:
+  Description: Check for deprecated class method calls.
+  Enabled: true
+  VersionAdded: '0.19'
+
+# Supports --auto-correct
+Lint/DeprecatedOpenSSLConstant:
+  Description: Don't use algorithm constants for `OpenSSL::Cipher` and `OpenSSL::Digest`.
+  Enabled: true
+  VersionAdded: '0.84'
+
+# Supports --auto-correct
+Lint/DisjunctiveAssignmentInConstructor:
+  Description: In constructor, plain assignment is preferred over disjunctive.
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.62'
+  VersionChanged: '0.88'
+
+Lint/DuplicateCaseCondition:
+  Description: Do not repeat values in case conditionals.
+  Enabled: true
+  VersionAdded: '0.45'
+
+Lint/DuplicateElsifCondition:
+  Description: Do not repeat conditions used in if `elsif`.
+  Enabled: true
+  VersionAdded: '0.88'
+
+Lint/DuplicateHashKey:
+  Description: Check for duplicate keys in hash literals.
+  Enabled: true
+  VersionAdded: '0.34'
+  VersionChanged: '0.77'
+
+Lint/DuplicateMethods:
+  Description: Check for duplicate method definitions.
+  Enabled: true
+  VersionAdded: '0.29'
+
+Lint/DuplicateRequire:
+  Description: Check for duplicate `require`s and `require_relative`s.
+  Enabled: true
+  VersionAdded: '0.90'
+
+Lint/DuplicateRescueException:
+  Description: Checks that there are no repeated exceptions used in `rescue` expressions.
+  Enabled: true
+  VersionAdded: '0.89'
+
+Lint/EachWithObjectArgument:
+  Description: Check for immutable argument given to each_with_object.
+  Enabled: true
+  VersionAdded: '0.31'
+
+Lint/ElseLayout:
+  Description: Check for odd code arrangement in an else block.
+  Enabled: true
+  VersionAdded: '0.17'
+
+Lint/EmptyConditionalBody:
+  Description: This cop checks for the presence of `if`, `elsif` and `unless` branches
+    without a body.
+  Enabled: true
+  AllowComments: true
+  VersionAdded: '0.89'
+
+# Supports --auto-correct
+Lint/EmptyEnsure:
+  Description: Checks for empty ensure block.
+  Enabled: true
+  VersionAdded: '0.10'
+  VersionChanged: '0.48'
+
+Lint/EmptyExpression:
+  Description: Checks for empty expressions.
+  Enabled: true
+  VersionAdded: '0.45'
+
+Lint/EmptyFile:
+  Description: Enforces that Ruby source files are not empty.
+  Enabled: true
+  AllowComments: true
+  VersionAdded: '0.90'
+
+# Supports --auto-correct
+Lint/EmptyInterpolation:
+  Description: Checks for empty string interpolation.
+  Enabled: true
+  VersionAdded: '0.20'
+  VersionChanged: '0.45'
+
+Lint/EmptyWhen:
+  Description: Checks for `when` branches with empty bodies.
+  Enabled: true
+  AllowComments: true
+  VersionAdded: '0.45'
+  VersionChanged: '0.83'
+
+# Supports --auto-correct
+Lint/EnsureReturn:
+  Description: Do not use return in an ensure block.
+  StyleGuide: "#no-return-ensure"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.83'
+
+# Supports --auto-correct
+Lint/ErbNewArguments:
+  Description: Use `:trim_mode` and `:eoutvar` keyword arguments to `ERB.new`.
+  Enabled: true
+  VersionAdded: '0.56'
+
+Lint/FlipFlop:
+  Description: Checks for flip-flops.
+  StyleGuide: "#no-flip-flops"
+  Enabled: true
+  VersionAdded: '0.16'
+
+Lint/FloatComparison:
+  Description: Checks for the presence of precise comparison of floating point numbers.
+  StyleGuide: "#float-comparison"
+  Enabled: true
+  VersionAdded: '0.89'
+
+Lint/FloatOutOfRange:
+  Description: Catches floating-point literals too large or small for Ruby to represent.
+  Enabled: true
+  VersionAdded: '0.36'
+
+Lint/FormatParameterMismatch:
+  Description: The number of parameters to format/sprint must match the fields.
+  Enabled: true
+  VersionAdded: '0.33'
+
+Lint/HashCompareByIdentity:
+  Description: Prefer using `Hash#compare_by_identity` than using `object_id` for keys.
+  StyleGuide: "#identity-comparison"
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.93'
+
+# Supports --auto-correct
+Lint/HeredocMethodCallPosition:
+  Description: Checks for the ordering of a method call where the receiver of the call
+    is a HEREDOC.
+  Enabled: false
+  StyleGuide: "#heredoc-method-calls"
+  VersionAdded: '0.68'
+
+# Supports --auto-correct
+Lint/IdentityComparison:
+  Description: Prefer `equal?` over `==` when comparing `object_id`.
+  Enabled: true
+  StyleGuide: "#identity-comparison"
+  VersionAdded: '0.91'
+
+Lint/ImplicitStringConcatenation:
+  Description: Checks for adjacent string literals on the same line, which could better
+    be represented as a single string literal.
+  Enabled: true
+  VersionAdded: '0.36'
+
+Lint/IneffectiveAccessModifier:
+  Description: Checks for attempts to use `private` or `protected` to set the visibility
+    of a class method, which does not work.
+  Enabled: true
+  VersionAdded: '0.36'
+
+# Supports --auto-correct
+Lint/InheritException:
+  Description: Avoid inheriting from the `Exception` class.
+  Enabled: true
+  VersionAdded: '0.41'
+  EnforcedStyle: runtime_error
+  SupportedStyles:
+  - runtime_error
+  - standard_error
+
+# Supports --auto-correct
+Lint/InterpolationCheck:
+  Description: Raise warning for interpolation in single q strs.
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.50'
+  VersionChanged: '0.87'
+
+Lint/LiteralAsCondition:
+  Description: Checks of literals used in conditions.
+  Enabled: true
+  VersionAdded: '0.51'
+
+# Supports --auto-correct
+Lint/LiteralInInterpolation:
+  Description: Checks for literals used in interpolation.
+  Enabled: true
+  VersionAdded: '0.19'
+  VersionChanged: '0.32'
+
+# Supports --auto-correct
+Lint/Loop:
+  Description: Use Kernel#loop with break rather than begin/end/until or begin/end/while
+    for post-loop tests.
+  StyleGuide: "#loop-with-break"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.89'
+
+Lint/MissingCopEnableDirective:
+  Description: Checks for a `# rubocop:enable` after `# rubocop:disable`.
+  Enabled: true
+  VersionAdded: '0.52'
+  MaximumRangeSize: .inf
+
+Lint/MixedRegexpCaptureTypes:
+  Description: Do not mix named captures and numbered captures in a Regexp literal.
+  Enabled: true
+  VersionAdded: '0.85'
+
+# Supports --auto-correct
+Lint/MultipleComparison:
+  Description: Use `&&` operator to compare multiple values.
+  Enabled: true
+  VersionAdded: '0.47'
+  VersionChanged: '0.77'
+
+Lint/NestedMethodDefinition:
+  Description: Do not use nested method definitions.
+  StyleGuide: "#no-nested-methods"
+  Enabled: true
+  VersionAdded: '0.32'
+
+Lint/NestedPercentLiteral:
+  Description: Checks for nested percent literals.
+  Enabled: true
+  VersionAdded: '0.52'
+
+Lint/NextWithoutAccumulator:
+  Description: Do not omit the accumulator when calling `next` in a `reduce`/`inject`
+    block.
+  Enabled: true
+  VersionAdded: '0.36'
+
+# Supports --auto-correct
+Lint/NonDeterministicRequireOrder:
+  Description: Always sort arrays returned by Dir.glob when requiring files.
+  Enabled: true
+  VersionAdded: '0.78'
+  Safe: false
+
+Lint/NonLocalExitFromIterator:
+  Description: Do not use return in iterator to cause non-local exit.
+  Enabled: true
+  VersionAdded: '0.30'
+
+# Supports --auto-correct
+Lint/NumberConversion:
+  Description: Checks unsafe usage of number conversion methods.
+  Enabled: false
+  VersionAdded: '0.53'
+  VersionChanged: '0.70'
+  SafeAutoCorrect: false
+
+# Supports --auto-correct
+Lint/OrderedMagicComments:
+  Description: Checks the proper ordering of magic comments and whether a magic comment
+    is not placed before a shebang.
+  Enabled: true
+  VersionAdded: '0.53'
+
+Lint/OutOfRangeRegexpRef:
+  Description: Checks for out of range reference for Regexp because it always returns
+    nil.
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.89'
+
+# Supports --auto-correct
+Lint/ParenthesesAsGroupedExpression:
+  Description: Checks for method calls with a space before the opening parenthesis.
+  StyleGuide: "#parens-no-spaces"
+  Enabled: true
+  VersionAdded: '0.12'
+  VersionChanged: '0.83'
+
+# Supports --auto-correct
+Lint/PercentStringArray:
+  Description: Checks for unwanted commas and quotes in %w/%W literals.
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.41'
+
+# Supports --auto-correct
+Lint/PercentSymbolArray:
+  Description: Checks for unwanted commas and colons in %i/%I literals.
+  Enabled: true
+  VersionAdded: '0.41'
+
+# Supports --auto-correct
+Lint/RaiseException:
+  Description: Checks for `raise` or `fail` statements which are raising `Exception`
+    class.
+  StyleGuide: "#raise-exception"
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.81'
+  VersionChanged: '0.86'
+  AllowedImplicitNamespaces:
+  - Gem
+
+Lint/RandOne:
+  Description: Checks for `rand(1)` calls. Such calls always return `0` and most likely
+    a mistake.
+  Enabled: true
+  VersionAdded: '0.36'
+
+# Supports --auto-correct
+Lint/RedundantCopDisableDirective:
+  Description: 'Checks for rubocop:disable comments that can be removed. Note: this
+    cop is not disabled when disabling all cops. It must be explicitly disabled.'
+  Enabled: true
+  VersionAdded: '0.76'
+
+# Supports --auto-correct
+Lint/RedundantCopEnableDirective:
+  Description: Checks for rubocop:enable comments that can be removed.
+  Enabled: true
+  VersionAdded: '0.76'
+
+# Supports --auto-correct
+Lint/RedundantRequireStatement:
+  Description: Checks for unnecessary `require` statement.
+  Enabled: true
+  VersionAdded: '0.76'
+
+# Supports --auto-correct
+Lint/RedundantSafeNavigation:
+  Description: Checks for redundant safe navigation calls.
+  Enabled: true
+  VersionAdded: '0.93'
+  AllowedMethods:
+  - instance_of?
+  - kind_of?
+  - is_a?
+  - eql?
+  - respond_to?
+  - equal?
+  Safe: false
+
+# Supports --auto-correct
+Lint/RedundantSplatExpansion:
+  Description: Checks for splat unnecessarily being called on literals.
+  Enabled: true
+  VersionAdded: '0.76'
+
+# Supports --auto-correct
+Lint/RedundantStringCoercion:
+  Description: Checks for Object#to_s usage in string interpolation.
+  StyleGuide: "#no-to-s"
+  Enabled: true
+  VersionAdded: '0.19'
+  VersionChanged: '0.77'
+
+# Supports --auto-correct
+Lint/RedundantWithIndex:
+  Description: Checks for redundant `with_index`.
+  Enabled: true
+  VersionAdded: '0.50'
+
+# Supports --auto-correct
+Lint/RedundantWithObject:
+  Description: Checks for redundant `with_object`.
+  Enabled: true
+  VersionAdded: '0.51'
+
+# Supports --auto-correct
+Lint/RegexpAsCondition:
+  Description: Do not use regexp literal as a condition. The regexp literal matches
+    `$_` implicitly.
+  Enabled: true
+  VersionAdded: '0.51'
+  VersionChanged: '0.86'
+
+Lint/RequireParentheses:
+  Description: Use parentheses in the method call to avoid confusion about precedence.
+  Enabled: true
+  VersionAdded: '0.18'
+
+Lint/RescueException:
+  Description: Avoid rescuing the Exception class.
+  StyleGuide: "#no-blind-rescues"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: 0.27.1
+
+# Supports --auto-correct
+Lint/RescueType:
+  Description: Avoid rescuing from non constants that could result in a `TypeError`.
+  Enabled: true
+  VersionAdded: '0.49'
+
+Lint/ReturnInVoidContext:
+  Description: Checks for return in void context.
+  Enabled: true
+  VersionAdded: '0.50'
+
+Lint/SafeNavigationChain:
+  Description: Do not chain ordinary method call after safe navigation operator.
+  Enabled: true
+  VersionAdded: '0.47'
+  VersionChanged: '0.77'
+  AllowedMethods:
+  - present?
+  - blank?
+  - presence
+  - try
+  - try!
+  - in?
+
+# Supports --auto-correct
+Lint/SafeNavigationConsistency:
+  Description: Check to make sure that if safe navigation is used for a method call
+    in an `&&` or `||` condition that safe navigation is used for all method calls on
+    that same object.
+  Enabled: true
+  VersionAdded: '0.55'
+  VersionChanged: '0.77'
+  AllowedMethods:
+  - present?
+  - blank?
+  - presence
+  - try
+  - try!
+
+# Supports --auto-correct
+Lint/SafeNavigationWithEmpty:
+  Description: Avoid `foo&.empty?` in conditionals.
+  Enabled: true
+  VersionAdded: '0.62'
+  VersionChanged: '0.87'
+
+# Supports --auto-correct
+Lint/ScriptPermission:
+  Description: Grant script file execute permission.
+  Enabled: true
+  VersionAdded: '0.49'
+  VersionChanged: '0.50'
+
+Lint/SelfAssignment:
+  Description: Checks for self-assignments.
+  Enabled: true
+  VersionAdded: '0.89'
+
+# Supports --auto-correct
+Lint/SendWithMixinArgument:
+  Description: Checks for `send` method when using mixin.
+  Enabled: true
+  VersionAdded: '0.75'
+
+Lint/ShadowedArgument:
+  Description: Avoid reassigning arguments before they were used.
+  Enabled: true
+  VersionAdded: '0.52'
+  IgnoreImplicitReferences: false
+
+Lint/ShadowedException:
+  Description: Avoid rescuing a higher level exception before a lower level exception.
+  Enabled: true
+  VersionAdded: '0.41'
+
+Lint/ShadowingOuterLocalVariable:
+  Description: Do not use the same name as outer local variable for block arguments
+    or block local variables.
+  Enabled: true
+  VersionAdded: '0.9'
+
+Lint/StructNewOverride:
+  Description: Disallow overriding the `Struct` built-in methods via `Struct.new`.
+  Enabled: true
+  VersionAdded: '0.81'
+
+Lint/SuppressedException:
+  Description: Don't suppress exceptions.
+  StyleGuide: "#dont-hide-exceptions"
+  Enabled: true
+  AllowComments: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.81'
+
+Lint/Syntax:
+  Description: Checks syntax error.
+  Enabled: true
+  VersionAdded: '0.9'
+
+# Supports --auto-correct
+Lint/ToJSON:
+  Description: 'Ensure #to_json includes an optional argument.'
+  Enabled: true
+  VersionAdded: '0.66'
+
+Lint/TopLevelReturnWithArgument:
+  Description: This cop detects top level return statements with argument.
+  Enabled: true
+  VersionAdded: '0.89'
+
+# Supports --auto-correct
+Lint/TrailingCommaInAttributeDeclaration:
+  Description: This cop checks for trailing commas in attribute declarations.
+  Enabled: true
+  VersionAdded: '0.90'
+
+Lint/UnderscorePrefixedVariableName:
+  Description: Do not use prefix `_` for a variable that is used.
+  Enabled: true
+  VersionAdded: '0.21'
+  AllowKeywordBlockArguments: false
+
+# Supports --auto-correct
+Lint/UnifiedInteger:
+  Description: Use Integer instead of Fixnum or Bignum.
+  Enabled: true
+  VersionAdded: '0.43'
+
+Lint/UnreachableCode:
+  Description: Unreachable code.
+  Enabled: true
+  VersionAdded: '0.9'
+
+Lint/UnreachableLoop:
+  Description: This cop checks for loops that will have at most one iteration.
+  Enabled: true
+  VersionAdded: '0.89'
+
+# Supports --auto-correct
+Lint/UnusedBlockArgument:
+  Description: Checks for unused block arguments.
+  StyleGuide: "#underscore-unused-vars"
+  Enabled: true
+  VersionAdded: '0.21'
+  VersionChanged: '0.22'
+  IgnoreEmptyBlocks: true
+  AllowUnusedKeywordArguments: false
+
+# Supports --auto-correct
+Lint/UnusedMethodArgument:
+  Description: Checks for unused method arguments.
+  StyleGuide: "#underscore-unused-vars"
+  Enabled: true
+  VersionAdded: '0.21'
+  VersionChanged: '0.81'
+  AllowUnusedKeywordArguments: false
+  IgnoreEmptyMethods: true
+  IgnoreNotImplementedMethods: true
+
+Lint/UriEscapeUnescape:
+  Description: "`URI.escape` method is obsolete and should not be used. Instead, use
+    `CGI.escape`, `URI.encode_www_form` or `URI.encode_www_form_component` de
+    on your specific use case. Also `URI.unescape` method is obsolete and should not
+    be used. Instead, use `CGI.unescape`, `URI.decode_www_form` or `URI.decode_www_form_component`
+    de on your specific use case."
+  Enabled: true
+  VersionAdded: '0.50'
+
+# Supports --auto-correct
+Lint/UriRegexp:
+  Description: Use `URI::DEFAULT_PARSER.make_regexp` instead of `URI.regexp`.
+  Enabled: true
+  VersionAdded: '0.50'
+
+# Supports --auto-correct
+Lint/UselessAccessModifier:
+  Description: Checks for useless access modifiers.
+  Enabled: true
+  VersionAdded: '0.20'
+  VersionChanged: '0.83'
+  ContextCreatingMethods: []
+  MethodCreatingMethods: []
+
+Lint/UselessAssignment:
+  Description: Checks for useless assignment to a local variable.
+  StyleGuide: "#underscore-unused-vars"
+  Enabled: true
+  VersionAdded: '0.11'
+
+Lint/UselessElseWithoutRescue:
+  Description: Checks for useless `else` in `begin..end` without `rescue`.
+  Enabled: true
+  VersionAdded: '0.17'
+
+# Supports --auto-correct
+Lint/UselessMethodDefinition:
+  Description: Checks for useless method definitions.
+  Enabled: true
+  VersionAdded: '0.90'
+  Safe: false
+  AllowComments: true
+
+Lint/UselessSetterCall:
+  Description: Checks for useless setter call to a local variable.
+  Enabled: true
+  VersionAdded: '0.13'
+  VersionChanged: '0.80'
+  Safe: false
+
+# Supports --auto-correct
+Lint/UselessTimes:
+  Description: Checks for useless `Integer#times` calls.
+  Enabled: true
+  VersionAdded: '0.91'
+  Safe: false
+
+Lint/Void:
+  Description: Possible use of operator/literal/variable in void context.
+  Enabled: true
+  VersionAdded: '0.9'
+  CheckForMethodsWithNoSideEffects: false
+
+# Department 'Migration' (1):
+# Supports --auto-correct
+Migration/DepartmentName:
+  Description: Check that cop names in rubocop:disable (etc) comments are given with
+    department name.
+  Enabled: true
+  VersionAdded: '0.75'
+
+# Department 'Naming' (16):
+Naming/AccessorMethodName:
+  Description: Check the naming of accessor methods for get_/set_.
+  StyleGuide: "#accessor_mutator_method_names"
+  Enabled: true
+  VersionAdded: '0.50'
+
+Naming/AsciiIdentifiers:
+  Description: Use only ascii symbols in identifiers and constants.
+  StyleGuide: "#english-identifiers"
+  Enabled: true
+  VersionAdded: '0.50'
+  VersionChanged: '0.87'
+  AsciiConstants: true
+
+Naming/BinaryOperatorParameterName:
+  Description: When defining binary operators, name the argument other.
+  StyleGuide: "#other-arg"
+  Enabled: true
+  VersionAdded: '0.50'
+
+Naming/BlockParameterName:
+  Description: Checks for block parameter names that contain capital letters, end in
+    numbers, or do not meet a minimal length.
+  Enabled: true
+  VersionAdded: '0.53'
+  VersionChanged: '0.77'
+  MinNameLength: 1
+  AllowNamesEndingInNumbers: true
+  AllowedNames: []
+  ForbiddenNames: []
+
+Naming/ClassAndModuleCamelCase:
+  Description: Use CamelCase for classes and modules.
+  StyleGuide: "#camelcase-classes"
+  Enabled: true
+  VersionAdded: '0.50'
+  VersionChanged: '0.85'
+  AllowedNames:
+  - module_parent
+
+Naming/ConstantName:
+  Description: Constants should use SCREAMING_SNAKE_CASE.
+  StyleGuide: "#screaming-snake-case"
+  Enabled: true
+  VersionAdded: '0.50'
 
 Naming/FileName:
+  Description: Use snake_case for source file names.
+  StyleGuide: "#snake-case-files"
+  Enabled: true
+  VersionAdded: '0.50'
   Exclude:
-    - lib/pry-byebug.rb
-    - pry-byebug.gemspec
+  - lib/pry-byebug.rb
+  - pry-byebug.gemspec
+  ExpectMatchingDefinition: false
+  CheckDefinitionPathHierarchy: true
+  Regex:
+  IgnoreExecutableScripts: true
+  AllowedAcronyms:
+  - CLI
+  - DSL
+  - ACL
+  - API
+  - ASCII
+  - CPU
+  - CSS
+  - DNS
+  - EOF
+  - GUID
+  - HTML
+  - HTTP
+  - HTTPS
+  - ID
+  - IP
+  - JSON
+  - LHS
+  - QPS
+  - RAM
+  - RHS
+  - RPC
+  - SLA
+  - SMTP
+  - SQL
+  - SSH
+  - TCP
+  - TLS
+  - TTL
+  - UDP
+  - UI
+  - UID
+  - UUID
+  - URI
+  - URL
+  - UTF8
+  - VM
+  - XML
+  - XMPP
+  - XSRF
+  - XSS
+
+Naming/HeredocDelimiterCase:
+  Description: Use configured case for heredoc delimiters.
+  StyleGuide: "#heredoc-delimiters"
+  Enabled: true
+  VersionAdded: '0.50'
+  EnforcedStyle: uppercase
+  SupportedStyles:
+  - lowercase
+  - uppercase
+
+Naming/HeredocDelimiterNaming:
+  Description: Use descriptive heredoc delimiters.
+  StyleGuide: "#heredoc-delimiters"
+  Enabled: true
+  VersionAdded: '0.50'
+  ForbiddenDelimiters:
+  - !ruby/regexp /(^|\s)(EO[A-Z]{1}|END)(\s|$)/
+
+Naming/MemoizedInstanceVariableName:
+  Description: Memoized method name should match memo instance variable name.
+  Enabled: true
+  VersionAdded: '0.53'
+  VersionChanged: '0.58'
+  EnforcedStyleForLeadingUnderscores: disallowed
+  SupportedStylesForLeadingUnderscores:
+  - disallowed
+  - required
+  - optional
+
+Naming/MethodName:
+  Description: Use the configured style when naming methods.
+  StyleGuide: "#snake-case-symbols-methods-vars"
+  Enabled: true
+  VersionAdded: '0.50'
+  EnforcedStyle: snake_case
+  SupportedStyles:
+  - snake_case
+  - camelCase
+  IgnoredPatterns: []
+
+Naming/MethodParameterName:
+  Description: Checks for method parameter names that contain capital letters, end in
+    numbers, or do not meet a minimal length.
+  Enabled: true
+  VersionAdded: '0.53'
+  VersionChanged: '0.77'
+  MinNameLength: 3
+  AllowNamesEndingInNumbers: true
+  AllowedNames:
+  - at
+  - by
+  - db
+  - id
+  - in
+  - io
+  - ip
+  - of
+  - 'on'
+  - os
+  - pp
+  - to
+  ForbiddenNames: []
+
+Naming/PredicateName:
+  Description: Check the names of predicate methods.
+  StyleGuide: "#bool-methods-qmark"
+  Enabled: true
+  VersionAdded: '0.50'
+  VersionChanged: '0.77'
+  NamePrefix:
+  - is_
+  - has_
+  - have_
+  ForbiddenPrefixes:
+  - is_
+  - has_
+  - have_
+  AllowedMethods:
+  - is_a?
+  MethodDefinitionMacros:
+  - define_method
+  - define_singleton_method
+  Exclude:
+  - "spec/**/*"
+
+# Supports --auto-correct
+Naming/RescuedExceptionsVariableName:
+  Description: Use consistent rescued exceptions variables naming.
+  Enabled: true
+  VersionAdded: '0.67'
+  VersionChanged: '0.68'
+  PreferredName: e
+
+Naming/VariableName:
+  Description: Use the configured style when naming variables.
+  StyleGuide: "#snake-case-symbols-methods-vars"
+  Enabled: true
+  VersionAdded: '0.50'
+  EnforcedStyle: snake_case
+  SupportedStyles:
+  - snake_case
+  - camelCase
+
+Naming/VariableNumber:
+  Description: Use the configured style when numbering variables.
+  Enabled: true
+  VersionAdded: '0.50'
+  EnforcedStyle: normalcase
+  SupportedStyles:
+  - snake_case
+  - normalcase
+  - non_integer
+
+# Department 'Security' (5):
+Security/Eval:
+  Description: The use of eval represents a serious security risk.
+  Enabled: true
+  VersionAdded: '0.47'
+
+# Supports --auto-correct
+Security/JSONLoad:
+  Description: Prefer usage of `JSON.parse` over `JSON.load` due to potential security
+    issues. See reference for more information.
+  Reference: https://ruby-doc.org/stdlib-2.7.0/libdoc/json/rdoc/JSON.html#method-i-load
+  Enabled: true
+  VersionAdded: '0.43'
+  VersionChanged: '0.44'
+  AutoCorrect: false
+  SafeAutoCorrect: false
+
+Security/MarshalLoad:
+  Description: Avoid using of `Marshal.load` or `Marshal.restore` due to potential security
+    issues. See reference for more information.
+  Reference: https://ruby-doc.org/core-2.7.0/Marshal.html#module-Marshal-label-Security+considerations
+  Enabled: true
+  VersionAdded: '0.47'
+
+Security/Open:
+  Description: The use of Kernel#open represents a serious security risk.
+  Enabled: true
+  VersionAdded: '0.53'
+  Safe: false
+
+# Supports --auto-correct
+Security/YAMLLoad:
+  Description: Prefer usage of `YAML.safe_load` over `YAML.load` due to potential security
+    issues. See reference for more information.
+  Reference: https://ruby-doc.org/stdlib-2.7.0/libdoc/yaml/rdoc/YAML.html#module-YAML-label-Security
+  Enabled: true
+  VersionAdded: '0.47'
+  SafeAutoCorrect: false
+
+# Department 'Style' (197):
+Style/AccessModifierDeclarations:
+  Description: Checks style of how access modifiers are used.
+  Enabled: true
+  VersionAdded: '0.57'
+  VersionChanged: '0.81'
+  EnforcedStyle: group
+  SupportedStyles:
+  - inline
+  - group
+  AllowModifiersOnSymbols: true
+
+# Supports --auto-correct
+Style/AccessorGrouping:
+  Description: Checks for grouping of accessors in `class` and `module` bodies.
+  Enabled: true
+  VersionAdded: '0.87'
+  EnforcedStyle: grouped
+  SupportedStyles:
+  - separated
+  - grouped
+
+# Supports --auto-correct
+Style/Alias:
+  Description: Use alias instead of alias_method.
+  StyleGuide: "#alias-method-lexically"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.36'
+  EnforcedStyle: prefer_alias
+  SupportedStyles:
+  - prefer_alias
+  - prefer_alias_method
+
+# Supports --auto-correct
+Style/AndOr:
+  Description: Use &&/|| instead of and/or.
+  StyleGuide: "#no-and-or-or"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.25'
+  EnforcedStyle: conditionals
+  SupportedStyles:
+  - always
+  - conditionals
+
+# Supports --auto-correct
+Style/ArrayCoercion:
+  Description: Use Array() instead of explicit Array check or [*var], when dealing with
+    a variable you want to treat as an Array, but you're not certain it's an array.
+  StyleGuide: "#array-coercion"
+  Safe: false
+  Enabled: false
+  VersionAdded: '0.88'
+
+# Supports --auto-correct
+Style/ArrayJoin:
+  Description: Use Array#join instead of Array#*.
+  StyleGuide: "#array-join"
+  Enabled: true
+  VersionAdded: '0.20'
+  VersionChanged: '0.31'
+
+Style/AsciiComments:
+  Description: Use only ascii symbols in comments.
+  StyleGuide: "#english-comments"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.52'
+  AllowedChars: []
+
+# Supports --auto-correct
+Style/Attr:
+  Description: Checks for uses of Module#attr.
+  StyleGuide: "#attr"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.12'
+
+Style/AutoResourceCleanup:
+  Description: Suggests the usage of an auto resource cleanup version of a method (if
+    available).
+  Enabled: false
+  VersionAdded: '0.30'
+
+# Supports --auto-correct
+Style/BarePercentLiterals:
+  Description: Checks if usage of %() or %Q() matches configuration.
+  StyleGuide: "#percent-q-shorthand"
+  Enabled: true
+  VersionAdded: '0.25'
+  EnforcedStyle: bare_percent
+  SupportedStyles:
+  - percent_q
+  - bare_percent
+
+Style/BeginBlock:
+  Description: Avoid the use of BEGIN blocks.
+  StyleGuide: "#no-BEGIN-blocks"
+  Enabled: true
+  VersionAdded: '0.9'
+
+# Supports --auto-correct
+Style/BisectedAttrAccessor:
+  Description: Checks for places where `attr_reader` and `attr_writer` for the same
+    method can be combined into single `attr_accessor`.
+  Enabled: true
+  VersionAdded: '0.87'
+
+# Supports --auto-correct
+Style/BlockComments:
+  Description: Do not use block comments.
+  StyleGuide: "#no-block-comments"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.23'
+
+# Supports --auto-correct
+Style/BlockDelimiters:
+  Description: Avoid using {...} for multi-line blocks (multiline chaining is always
+    ugly). Prefer {...} over do...end for single-line blocks.
+  StyleGuide: "#single-line-blocks"
+  Enabled: true
+  VersionAdded: '0.30'
+  VersionChanged: '0.35'
+  EnforcedStyle: line_count_based
+  SupportedStyles:
+  - line_count_based
+  - semantic
+  - braces_for_chaining
+  - always_braces
+  ProceduralMethods:
+  - benchmark
+  - bm
+  - bmbm
+  - create
+  - each_with_object
+  - measure
+  - new
+  - realtime
+  - tap
+  - with_object
+  FunctionalMethods:
+  - let
+  - let!
+  - subject
+  - watch
+  IgnoredMethods:
+  - lambda
+  - proc
+  - it
+  AllowBracesOnProceduralOneLiners: false
+  BracesRequiredMethods: []
+
+# Supports --auto-correct
+Style/CaseEquality:
+  Description: Avoid explicit use of the case equality operator(===).
+  StyleGuide: "#no-case-equality"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.89'
+  AllowOnConstant: false
+
+# Supports --auto-correct
+Style/CaseLikeIf:
+  Description: This cop identifies places where `if-elsif` constructions can be replaced
+    with `case-when`.
+  StyleGuide: "#case-vs-if-else"
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.88'
+
+# Supports --auto-correct
+Style/CharacterLiteral:
+  Description: Checks for uses of character literals.
+  StyleGuide: "#no-character-literals"
+  Enabled: true
+  VersionAdded: '0.9'
+
+# Supports --auto-correct
+Style/ClassAndModuleChildren:
+  Description: Checks style of children classes and modules.
+  StyleGuide: "#namespace-definition"
+  SafeAutoCorrect: false
+  Enabled: true
+  VersionAdded: '0.19'
+  EnforcedStyle: nested
+  SupportedStyles:
+  - nested
+  - compact
+
+# Supports --auto-correct
+Style/ClassCheck:
+  Description: Enforces consistent use of `Object#is_a?` or `Object#kind_of?`.
+  StyleGuide: "#is-a-vs-kind-of"
+  Enabled: true
+  VersionAdded: '0.24'
+  EnforcedStyle: is_a?
+  SupportedStyles:
+  - is_a?
+  - kind_of?
+
+# Supports --auto-correct
+Style/ClassEqualityComparison:
+  Description: Enforces the use of `Object#instance_of?` instead of class comparison
+    for equality.
+  StyleGuide: "#instance-of-vs-class-comparison"
+  Enabled: true
+  VersionAdded: '0.93'
+  IgnoredMethods:
+  - "=="
+  - equal?
+  - eql?
+
+# Supports --auto-correct
+Style/ClassMethods:
+  Description: Use self when defining module/class methods.
+  StyleGuide: "#def-self-class-methods"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.20'
+
+# Supports --auto-correct
+Style/ClassMethodsDefinitions:
+  Description: Enforces using `def self.method_name` or `class << self` to define class
+    methods.
+  StyleGuide: "#def-self-class-methods"
+  Enabled: false
+  VersionAdded: '0.89'
+  EnforcedStyle: def_self
+  SupportedStyles:
+  - def_self
+  - self_class
+
+Style/ClassVars:
+  Description: Avoid the use of class variables.
+  StyleGuide: "#no-class-vars"
+  Enabled: true
+  VersionAdded: '0.13'
+
+# Supports --auto-correct
+Style/CollectionMethods:
+  Description: Preferred collection methods.
+  StyleGuide: "#map-find-select-reduce-include-size"
+  Enabled: false
+  VersionAdded: '0.9'
+  VersionChanged: '0.27'
+  Safe: false
+  PreferredMethods:
+    collect: map
+    collect!: map!
+    inject: reduce
+    detect: find
+    find_all: select
+    member?: include?
+
+# Supports --auto-correct
+Style/ColonMethodCall:
+  Description: 'Do not use :: for method call.'
+  StyleGuide: "#double-colons"
+  Enabled: true
+  VersionAdded: '0.9'
+
+# Supports --auto-correct
+Style/ColonMethodDefinition:
+  Description: 'Do not use :: for defining class methods.'
+  StyleGuide: "#colon-method-definition"
+  Enabled: true
+  VersionAdded: '0.52'
+
+Style/CombinableLoops:
+  Description: Checks for places where multiple consecutive loops over the same data
+    can be combined into a single loop.
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.90'
+
+# Supports --auto-correct
+Style/CommandLiteral:
+  Description: Use `` or %x around command literals.
+  StyleGuide: "#percent-x"
+  Enabled: true
+  VersionAdded: '0.30'
+  EnforcedStyle: backticks
+  SupportedStyles:
+  - backticks
+  - percent_x
+  - mixed
+  AllowInnerBackticks: false
+
+# Supports --auto-correct
+Style/CommentAnnotation:
+  Description: Checks formatting of special comments (TODO, FIXME, OPTIMIZE, HACK, REVIEW).
+  StyleGuide: "#annotate-keywords"
+  Enabled: true
+  VersionAdded: '0.10'
+  VersionChanged: '0.31'
+  Keywords:
+  - TODO
+  - FIXME
+  - OPTIMIZE
+  - HACK
+  - REVIEW
+
+Style/CommentedKeyword:
+  Description: Do not place comments on the same line as certain keywords.
+  Enabled: true
+  VersionAdded: '0.51'
+
+# Supports --auto-correct
+Style/ConditionalAssignment:
+  Description: Use the return value of `if` and `case` statements for assignment to
+    a variable and variable comparison instead of assigning that variable inside of
+    each branch.
+  Enabled: true
+  VersionAdded: '0.36'
+  VersionChanged: '0.47'
+  EnforcedStyle: assign_to_condition
+  SupportedStyles:
+  - assign_to_condition
+  - assign_inside_condition
+  SingleLineConditionsOnly: true
+  IncludeTernaryExpressions: true
+
+Style/ConstantVisibility:
+  Description: Check that class- and module constants have visibility declarations.
+  Enabled: false
+  VersionAdded: '0.66'
+
+# Supports --auto-correct
+Style/Copyright:
+  Description: Include a copyright notice in each file before any code.
+  Enabled: false
+  VersionAdded: '0.30'
+  Notice: "^Copyright (\\(c\\) )?2[0-9]{3} .+"
+  AutocorrectNotice: ''
+
+# Supports --auto-correct
+Style/DateTime:
+  Description: Use Time over DateTime.
+  StyleGuide: "#date--time"
+  Enabled: false
+  VersionAdded: '0.51'
+  VersionChanged: '0.92'
+  SafeAutoCorrect: false
+  AllowCoercion: false
+
+# Supports --auto-correct
+Style/DefWithParentheses:
+  Description: Use def with parentheses when there are arguments.
+  StyleGuide: "#method-parens"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.12'
+
+# Supports --auto-correct
+Style/Dir:
+  Description: Use the `__dir__` method to retrieve the canonicalized absolute path
+    to the current file.
+  Enabled: true
+  VersionAdded: '0.50'
+
+# Supports --auto-correct
+Style/DisableCopsWithinSourceCodeDirective:
+  Description: Forbids disabling/enabling cops within source code.
+  Enabled: false
+  VersionAdded: '0.82'
+
+Style/Documentation:
+  Description: Document classes and non-namespace modules.
+  Enabled: true
+  VersionAdded: '0.9'
+  Exclude:
+  - "spec/**/*"
+  - "test/**/*"
+
+Style/DocumentationMethod:
+  Description: Checks for missing documentation comment for public methods.
+  Enabled: false
+  VersionAdded: '0.43'
+  Exclude:
+  - "spec/**/*"
+  - "test/**/*"
+  RequireForNonPublicMethods: false
+
+# Supports --auto-correct
+Style/DoubleCopDisableDirective:
+  Description: Checks for double rubocop:disable comments on a single line.
+  Enabled: true
+  VersionAdded: '0.73'
+
+Style/DoubleNegation:
+  Description: Checks for uses of double negation (!!).
+  StyleGuide: "#no-bang-bang"
+  Enabled: true
+  VersionAdded: '0.19'
+  VersionChanged: '0.84'
+  EnforcedStyle: allowed_in_returns
+  SafeAutoCorrect: false
+  SupportedStyles:
+  - allowed_in_returns
+  - forbidden
+
+# Supports --auto-correct
+Style/EachForSimpleLoop:
+  Description: Use `Integer#times` for a simple loop which iterates a fixed number of
+    times.
+  Enabled: true
+  VersionAdded: '0.41'
+
+# Supports --auto-correct
+Style/EachWithObject:
+  Description: Prefer `each_with_object` over `inject` or `reduce`.
+  Enabled: true
+  VersionAdded: '0.22'
+  VersionChanged: '0.42'
+
+# Supports --auto-correct
+Style/EmptyBlockParameter:
+  Description: Omit pipes for empty block parameters.
+  Enabled: true
+  VersionAdded: '0.52'
+
+# Supports --auto-correct
+Style/EmptyCaseCondition:
+  Description: Avoid empty condition in case statements.
+  Enabled: true
+  VersionAdded: '0.40'
+
+# Supports --auto-correct
+Style/EmptyElse:
+  Description: Avoid empty else-clauses.
+  Enabled: true
+  VersionAdded: '0.28'
+  VersionChanged: '0.32'
+  EnforcedStyle: both
+  SupportedStyles:
+  - empty
+  - nil
+  - both
+
+# Supports --auto-correct
+Style/EmptyLambdaParameter:
+  Description: Omit parens for empty lambda parameters.
+  Enabled: true
+  VersionAdded: '0.52'
+
+# Supports --auto-correct
+Style/EmptyLiteral:
+  Description: Prefer literals to Array.new/Hash.new/String.new.
+  StyleGuide: "#literal-array-hash"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.12'
+
+# Supports --auto-correct
+Style/EmptyMethod:
+  Description: Checks the formatting of empty method definitions.
+  StyleGuide: "#no-single-line-methods"
+  Enabled: true
+  VersionAdded: '0.46'
+  EnforcedStyle: compact
+  SupportedStyles:
+  - compact
+  - expanded
+
+# Supports --auto-correct
+Style/Encoding:
+  Description: Use UTF-8 as the source file encoding.
+  StyleGuide: "#utf-8"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.50'
+
+# Supports --auto-correct
+Style/EndBlock:
+  Description: Avoid the use of END blocks.
+  StyleGuide: "#no-END-blocks"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.81'
+
+Style/EvalWithLocation:
+  Description: Pass `__FILE__` and `__LINE__` to `eval` method, as they are used by
+    backtraces.
+  Enabled: true
+  VersionAdded: '0.52'
+
+# Supports --auto-correct
+Style/EvenOdd:
+  Description: Favor the use of `Integer#even?` && `Integer#odd?`.
+  StyleGuide: "#predicate-methods"
+  Enabled: true
+  VersionAdded: '0.12'
+  VersionChanged: '0.29'
+
+# Supports --auto-correct
+Style/ExpandPathArguments:
+  Description: Use `expand_path(__dir__)` instead of `expand_path('..', __FILE__)`.
+  Enabled: true
+  VersionAdded: '0.53'
+
+Style/ExponentialNotation:
+  Description: When using exponential notation, favor a mantissa between 1 (inclusive)
+    and 10 (exclusive).
+  StyleGuide: "#exponential-notation"
+  Enabled: true
+  VersionAdded: '0.82'
+  EnforcedStyle: scientific
+  SupportedStyles:
+  - scientific
+  - engineering
+  - integral
+
+Style/FloatDivision:
+  Description: For performing float division, coerce one side only.
+  StyleGuide: "#float-division"
+  Reference: https://github.com/rubocop-hq/ruby-style-guide/issues/628
+  Enabled: true
+  VersionAdded: '0.72'
+  EnforcedStyle: single_coerce
+  SupportedStyles:
+  - left_coerce
+  - right_coerce
+  - single_coerce
+  - fdiv
+
+# Supports --auto-correct
+Style/For:
+  Description: Checks use of for or each in multiline loops.
+  StyleGuide: "#no-for-loops"
+  Enabled: true
+  VersionAdded: '0.13'
+  VersionChanged: '0.59'
+  EnforcedStyle: each
+  SupportedStyles:
+  - each
+  - for
+
+# Supports --auto-correct
+Style/FormatString:
+  Description: Enforce the use of Kernel#sprintf, Kernel#format or String#%.
+  StyleGuide: "#sprintf"
+  Enabled: true
+  VersionAdded: '0.19'
+  VersionChanged: '0.49'
+  EnforcedStyle: format
+  SupportedStyles:
+  - format
+  - sprintf
+  - percent
 
 Style/FormatStringToken:
+  Description: Use a consistent style for format string tokens.
+  Enabled: true
   EnforcedStyle: unannotated
+  SupportedStyles:
+  - annotated
+  - template
+  - unannotated
+  VersionAdded: '0.49'
+  VersionChanged: '0.75'
 
+# Supports --auto-correct
+Style/FrozenStringLiteralComment:
+  Description: Add the frozen_string_literal comment to the top of files to help transition
+    to frozen string literals by default.
+  Enabled: true
+  VersionAdded: '0.36'
+  VersionChanged: '0.79'
+  EnforcedStyle: always
+  SupportedStyles:
+  - always
+  - always_true
+  - never
+  SafeAutoCorrect: false
+
+# Supports --auto-correct
+Style/GlobalStdStream:
+  Description: Enforces the use of `$stdout/$stderr/$stdin` instead of `STDOUT/STDERR/STDIN`.
+  StyleGuide: "#global-stdout"
+  Enabled: true
+  VersionAdded: '0.89'
+  SafeAutoCorrect: false
+
+Style/GlobalVars:
+  Description: Do not introduce global variables.
+  StyleGuide: "#instance-vars"
+  Reference: https://www.zenspider.com/ruby/quickref.html
+  Enabled: true
+  VersionAdded: '0.13'
+  AllowedVariables: []
+
+Style/GuardClause:
+  Description: Check for conditionals that can be replaced with guard clauses.
+  StyleGuide: "#no-nested-conditionals"
+  Enabled: true
+  VersionAdded: '0.20'
+  VersionChanged: '0.22'
+  MinBodyLength: 1
+
+# Supports --auto-correct
+Style/HashAsLastArrayItem:
+  Description: Checks for presence or absence of braces around hash literal as a last
+    array item de on configuration.
+  StyleGuide: "#hash-literal-as-last-array-item"
+  Enabled: true
+  VersionAdded: '0.88'
+  EnforcedStyle: braces
+  SupportedStyles:
+  - braces
+  - no_braces
+
+# Supports --auto-correct
 Style/HashEachMethods:
+  Description: Use Hash#each_key and Hash#each_value.
+  StyleGuide: "#hash-each"
   Enabled: true
+  VersionAdded: '0.80'
+  Safe: false
 
+Style/HashLikeCase:
+  Description: Checks for places where `case-when` represents a simple 1:1 mapping and
+    can be replaced with a hash lookup.
+  Enabled: true
+  VersionAdded: '0.88'
+  MinBranchesCount: 3
+
+# Supports --auto-correct
+Style/HashSyntax:
+  Description: 'Prefer Ruby 1.9 hash syntax { a: 1, b: 2 } over 1.8 syntax { :a => 1,
+    :b => 2 }.'
+  StyleGuide: "#hash-literals"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.43'
+  EnforcedStyle: ruby19
+  SupportedStyles:
+  - ruby19
+  - hash_rockets
+  - no_mixed_keys
+  - ruby19_no_mixed_keys
+  UseHashRocketsWithSymbolValues: false
+  PreferHashRocketsForNonAlnumEndingSymbols: false
+
+# Supports --auto-correct
 Style/HashTransformKeys:
+  Description: Prefer `transform_keys` over `each_with_object`, `map`, or `to_h`.
   Enabled: true
+  VersionAdded: '0.80'
+  VersionChanged: '0.90'
+  Safe: false
 
+# Supports --auto-correct
 Style/HashTransformValues:
+  Description: Prefer `transform_values` over `each_with_object`, `map`, or `to_h`.
   Enabled: true
+  VersionAdded: '0.80'
+  VersionChanged: '0.90'
+  Safe: false
 
-Style/ModuleFunction:
+Style/IdenticalConditionalBranches:
+  Description: Checks that conditional statements do not have an identical line at the
+    end of each branch, which can validly be moved out of the conditional.
+  Enabled: true
+  VersionAdded: '0.36'
+
+Style/IfInsideElse:
+  Description: Finds if nodes inside else, which can be converted to elsif.
+  Enabled: true
+  AllowIfModifier: false
+  VersionAdded: '0.36'
+
+# Supports --auto-correct
+Style/IfUnlessModifier:
+  Description: Favor modifier if/unless usage when you have a single-line body.
+  StyleGuide: "#if-as-a-modifier"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.30'
+
+# Supports --auto-correct
+Style/IfUnlessModifierOfIfUnless:
+  Description: Avoid modifier if/unless usage on conditionals.
+  Enabled: true
+  VersionAdded: '0.39'
+  VersionChanged: '0.87'
+
+# Supports --auto-correct
+Style/IfWithSemicolon:
+  Description: Do not use if x; .... Use the ternary operator instead.
+  StyleGuide: "#no-semicolon-ifs"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.83'
+
+Style/ImplicitRuntimeError:
+  Description: Use `raise` or `fail` with an explicit exception class and message, rather
+    than just a message.
   Enabled: false
+  VersionAdded: '0.41'
 
+# Supports --auto-correct
+Style/InfiniteLoop:
+  Description: Use Kernel#loop for infinite loops.
+  StyleGuide: "#infinite-loop"
+  Enabled: true
+  VersionAdded: '0.26'
+  VersionChanged: '0.61'
+  SafeAutoCorrect: true
+
+Style/InlineComment:
+  Description: Avoid trailing inline comments.
+  Enabled: false
+  VersionAdded: '0.23'
+
+# Supports --auto-correct
+Style/InverseMethods:
+  Description: Use the inverse method instead of `!.method` if an inverse method is
+    defined.
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.48'
+  InverseMethods:
+    :any?: :none?
+    :even?: :odd?
+    :==: :!=
+    :=~: :!~
+    :<: :>=
+    :>: :<=
+  InverseBlocks:
+    :select: :reject
+    :select!: :reject!
+
+Style/IpAddresses:
+  Description: Don't include literal IP addresses in code.
+  Enabled: false
+  VersionAdded: '0.58'
+  VersionChanged: '0.91'
+  AllowedAddresses:
+  - "::"
+  Exclude:
+  - "**/*.gemfile"
+  - "**/Gemfile"
+  - "**/gems.rb"
+  - "**/*.gemspec"
+
+# Supports --auto-correct
+Style/KeywordParametersOrder:
+  Description: Enforces that optional keyword parameters are placed at the end of the
+    parameters list.
+  StyleGuide: "#keyword-parameters-order"
+  Enabled: true
+  VersionAdded: '0.90'
+
+# Supports --auto-correct
+Style/Lambda:
+  Description: Use the new lambda literal syntax for single-line blocks.
+  StyleGuide: "#lambda-multi-line"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.40'
+  EnforcedStyle: line_count_dependent
+  SupportedStyles:
+  - line_count_dependent
+  - lambda
+  - literal
+
+# Supports --auto-correct
+Style/LambdaCall:
+  Description: Use lambda.call(...) instead of lambda.(...).
+  StyleGuide: "#proc-call"
+  Enabled: true
+  VersionAdded: '0.13'
+  VersionChanged: '0.14'
+  EnforcedStyle: call
+  SupportedStyles:
+  - call
+  - braces
+
+# Supports --auto-correct
+Style/LineEndConcatenation:
+  Description: Use \ instead of + or << to concatenate two string literals at line end.
+  Enabled: true
+  SafeAutoCorrect: false
+  VersionAdded: '0.18'
+  VersionChanged: '0.64'
+
+# Supports --auto-correct
+Style/MethodCallWithArgsParentheses:
+  Description: Use parentheses for method calls with arguments.
+  StyleGuide: "#method-invocation-parens"
+  Enabled: false
+  VersionAdded: '0.47'
+  VersionChanged: '0.61'
+  IgnoreMacros: true
+  IgnoredMethods: []
+  IgnoredPatterns: []
+  IncludedMacros: []
+  AllowParenthesesInMultilineCall: false
+  AllowParenthesesInChaining: false
+  AllowParenthesesInCamelCaseMethod: false
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+  - require_parentheses
+  - omit_parentheses
+
+# Supports --auto-correct
+Style/MethodCallWithoutArgsParentheses:
+  Description: Do not use parentheses for method calls with no arguments.
+  StyleGuide: "#method-invocation-parens"
+  Enabled: true
+  IgnoredMethods: []
+  VersionAdded: '0.47'
+  VersionChanged: '0.55'
+
+Style/MethodCalledOnDoEndBlock:
+  Description: Avoid chaining a method call on a do...end block.
+  StyleGuide: "#single-line-blocks"
+  Enabled: false
+  VersionAdded: '0.14'
+
+# Supports --auto-correct
+Style/MethodDefParentheses:
+  Description: Checks if the method definitions have or don't have parentheses.
+  StyleGuide: "#method-parens"
+  Enabled: true
+  VersionAdded: '0.16'
+  VersionChanged: '0.35'
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+  - require_parentheses
+  - require_no_parentheses
+  - require_no_parentheses_except_multiline
+
+# Supports --auto-correct
+Style/MinMax:
+  Description: Use `Enumerable#minmax` instead of `Enumerable#min` and `Enumerable#max`
+    in conjunction.
+  Enabled: true
+  VersionAdded: '0.50'
+
+Style/MissingElse:
+  Description: Require if/case expressions to have an else branches. If enabled, it
+    is recommended that Style/UnlessElse and Style/EmptyElse be enabled. This will conflict
+    with Style/EmptyElse if Style/EmptyElse is configured to style "both".
+  Enabled: false
+  VersionAdded: '0.30'
+  VersionChanged: '0.38'
+  EnforcedStyle: both
+  SupportedStyles:
+  - if
+  - case
+  - both
+
+Style/MissingRespondToMissing:
+  Description: Checks if `method_missing` is implemented without implementing `respond_to_missing`.
+  StyleGuide: "#no-method-missing"
+  Enabled: true
+  VersionAdded: '0.56'
+
+# Supports --auto-correct
+Style/MixinGrouping:
+  Description: Checks for grouping of mixins in `class` and `module` bodies.
+  StyleGuide: "#mixin-grouping"
+  Enabled: true
+  VersionAdded: '0.48'
+  VersionChanged: '0.49'
+  EnforcedStyle: separated
+  SupportedStyles:
+  - separated
+  - grouped
+
+Style/MixinUsage:
+  Description: Checks that `include`, `extend` and `prepend` exists at the top level.
+  Enabled: true
+  VersionAdded: '0.51'
+
+Style/MultilineBlockChain:
+  Description: Avoid multi-line chains of blocks.
+  StyleGuide: "#single-line-blocks"
+  Enabled: true
+  VersionAdded: '0.13'
+
+# Supports --auto-correct
+Style/MultilineIfModifier:
+  Description: Only use if/unless modifiers on single line statements.
+  StyleGuide: "#no-multiline-if-modifiers"
+  Enabled: true
+  VersionAdded: '0.45'
+
+# Supports --auto-correct
+Style/MultilineIfThen:
+  Description: Do not use then for multi-line if/unless.
+  StyleGuide: "#no-then"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.26'
+
+# Supports --auto-correct
+Style/MultilineMemoization:
+  Description: Wrap multiline memoizations in a `begin` and `end` block.
+  Enabled: true
+  VersionAdded: '0.44'
+  VersionChanged: '0.48'
+  EnforcedStyle: keyword
+  SupportedStyles:
+  - keyword
+  - braces
+
+Style/MultilineMethodSignature:
+  Description: Avoid multi-line method signatures.
+  Enabled: false
+  VersionAdded: '0.59'
+
+# Supports --auto-correct
+Style/MultilineTernaryOperator:
+  Description: 'Avoid multi-line ?: (the ternary operator); use if/unless instead.'
+  StyleGuide: "#no-multiline-ternary"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.86'
+
+# Supports --auto-correct
+Style/MultilineWhenThen:
+  Description: Do not use then for multi-line when statement.
+  StyleGuide: "#no-then"
+  Enabled: true
+  VersionAdded: '0.73'
+
+Style/MultipleComparison:
+  Description: Avoid comparing a variable with multiple items in a conditional, use
+    Array#include? instead.
+  Enabled: true
+  VersionAdded: '0.49'
+
+# Supports --auto-correct
+Style/MutableConstant:
+  Description: Do not assign mutable objects to constants.
+  Enabled: true
+  VersionAdded: '0.34'
+  VersionChanged: '0.65'
+  EnforcedStyle: literals
+  SupportedStyles:
+  - literals
+  - strict
+
+# Supports --auto-correct
+Style/NegatedIf:
+  Description: Favor unless over if for negative conditions (or control flow or).
+  StyleGuide: "#unless-for-negatives"
+  Enabled: true
+  VersionAdded: '0.20'
+  VersionChanged: '0.48'
+  EnforcedStyle: both
+  SupportedStyles:
+  - both
+  - prefix
+  - postfix
+
+# Supports --auto-correct
+Style/NegatedUnless:
+  Description: Favor if over unless for negative conditions.
+  StyleGuide: "#if-for-negatives"
+  Enabled: true
+  VersionAdded: '0.69'
+  EnforcedStyle: both
+  SupportedStyles:
+  - both
+  - prefix
+  - postfix
+
+# Supports --auto-correct
+Style/NegatedWhile:
+  Description: Favor until over while for negative conditions.
+  StyleGuide: "#until-for-negatives"
+  Enabled: true
+  VersionAdded: '0.20'
+
+# Supports --auto-correct
+Style/NestedModifier:
+  Description: Avoid using nested modifiers.
+  StyleGuide: "#no-nested-modifiers"
+  Enabled: true
+  VersionAdded: '0.35'
+
+# Supports --auto-correct
+Style/NestedParenthesizedCalls:
+  Description: Parenthesize method calls which are nested inside the argument list of
+    another parenthesized method call.
+  Enabled: true
+  VersionAdded: '0.36'
+  VersionChanged: '0.77'
+  AllowedMethods:
+  - be
+  - be_a
+  - be_an
+  - be_between
+  - be_falsey
+  - be_kind_of
+  - be_instance_of
+  - be_truthy
+  - be_within
+  - eq
+  - eql
+  - end_with
+  - include
+  - match
+  - raise_error
+  - respond_to
+  - start_with
+
+# Supports --auto-correct
+Style/NestedTernaryOperator:
+  Description: Use one expression per branch in a ternary operator.
+  StyleGuide: "#no-nested-ternary"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.86'
+
+# Supports --auto-correct
+Style/Next:
+  Description: Use `next` to skip iteration instead of a condition at the end.
+  StyleGuide: "#no-nested-conditionals"
+  Enabled: true
+  VersionAdded: '0.22'
+  VersionChanged: '0.35'
+  EnforcedStyle: skip_modifier_ifs
+  MinBodyLength: 3
+  SupportedStyles:
+  - skip_modifier_ifs
+  - always
+
+# Supports --auto-correct
+Style/NilComparison:
+  Description: Prefer x.nil? to x == nil.
+  StyleGuide: "#predicate-methods"
+  Enabled: true
+  VersionAdded: '0.12'
+  VersionChanged: '0.59'
+  EnforcedStyle: predicate
+  SupportedStyles:
+  - predicate
+  - comparison
+
+# Supports --auto-correct
+Style/NonNilCheck:
+  Description: Checks for redundant nil checks.
+  StyleGuide: "#no-non-nil-checks"
+  Enabled: true
+  VersionAdded: '0.20'
+  VersionChanged: '0.22'
+  IncludeSemanticChanges: false
+
+# Supports --auto-correct
+Style/Not:
+  Description: Use ! instead of not.
+  StyleGuide: "#bang-not-not"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.20'
+
+# Supports --auto-correct
+Style/NumericLiteralPrefix:
+  Description: Use smallcase prefixes for numeric literals.
+  StyleGuide: "#numeric-literal-prefixes"
+  Enabled: true
+  VersionAdded: '0.41'
+  EnforcedOctalStyle: zero_with_o
+  SupportedOctalStyles:
+  - zero_with_o
+  - zero_only
+
+# Supports --auto-correct
+Style/NumericLiterals:
+  Description: Add underscores to large numeric literals to improve their readability.
+  StyleGuide: "#underscores-in-numerics"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.48'
+  MinDigits: 5
+  Strict: false
+
+# Supports --auto-correct
+Style/NumericPredicate:
+  Description: Checks for the use of predicate- or comparison methods for numeric comparisons.
+  StyleGuide: "#predicate-methods"
+  Safe: false
+  SafeAutoCorrect: false
+  Enabled: true
+  VersionAdded: '0.42'
+  VersionChanged: '0.59'
+  EnforcedStyle: predicate
+  SupportedStyles:
+  - predicate
+  - comparison
+  IgnoredMethods: []
+  Exclude:
+  - "spec/**/*"
+
+# Supports --auto-correct
+Style/OneLineConditional:
+  Description: Favor the ternary operator (?:) or multi-line constructs over single-line
+    if/then/else/end constructs.
+  StyleGuide: "#ternary-operator"
+  Enabled: true
+  AlwaysCorrectToMultiline: false
+  VersionAdded: '0.9'
+  VersionChanged: '0.90'
+
+Style/OptionHash:
+  Description: Don't use option hashes when you can use keyword arguments.
+  Enabled: false
+  VersionAdded: '0.33'
+  VersionChanged: '0.34'
+  SuspiciousParamNames:
+  - options
+  - opts
+  - args
+  - params
+  - parameters
+
+Style/OptionalArguments:
+  Description: Checks for optional arguments that do not appear at the end of the argument
+    list.
+  StyleGuide: "#optional-arguments"
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.33'
+  VersionChanged: '0.83'
+
+# Supports --auto-correct
+Style/OrAssignment:
+  Description: Recommend usage of double pipe equals (||=) where applicable.
+  StyleGuide: "#double-pipe-for-uninit"
+  Enabled: true
+  VersionAdded: '0.50'
+
+# Supports --auto-correct
+Style/ParallelAssignment:
+  Description: Check for simple usages of parallel assignment. It will only warn when
+    the number of variables matches on both sides of the assignment.
+  StyleGuide: "#parallel-assignment"
+  Enabled: true
+  VersionAdded: '0.32'
+
+# Supports --auto-correct
+Style/ParenthesesAroundCondition:
+  Description: Don't use parentheses around the condition of an if/unless/while.
+  StyleGuide: "#no-parens-around-condition"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.56'
+  AllowSafeAssignment: true
+  AllowInMultilineConditions: false
+
+# Supports --auto-correct
+Style/PercentLiteralDelimiters:
+  Description: Use `%`-literal delimiters consistently.
+  StyleGuide: "#percent-literal-braces"
+  Enabled: true
+  VersionAdded: '0.19'
+  PreferredDelimiters:
+    default: "()"
+    "%i": "[]"
+    "%I": "[]"
+    "%r": "{}"
+    "%w": "[]"
+    "%W": "[]"
+  VersionChanged: 0.48.1
+
+# Supports --auto-correct
+Style/PercentQLiterals:
+  Description: Checks if uses of %Q/%q match the configured preference.
+  Enabled: true
+  VersionAdded: '0.25'
+  EnforcedStyle: lower_case_q
+  SupportedStyles:
+  - lower_case_q
+  - upper_case_q
+
+# Supports --auto-correct
+Style/PerlBackrefs:
+  Description: Avoid Perl-style regex back references.
+  StyleGuide: "#no-perl-regexp-last-matchers"
+  Enabled: true
+  VersionAdded: '0.13'
+
+# Supports --auto-correct
+Style/PreferredHashMethods:
+  Description: Checks use of `has_key?` and `has_value?` Hash methods.
+  StyleGuide: "#hash-key"
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.41'
+  VersionChanged: '0.70'
+  EnforcedStyle: short
+  SupportedStyles:
+  - short
+  - verbose
+
+# Supports --auto-correct
+Style/Proc:
+  Description: Use proc instead of Proc.new.
+  StyleGuide: "#proc"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.18'
+
+# Supports --auto-correct
+Style/RaiseArgs:
+  Description: Checks the arguments passed to raise/fail.
+  StyleGuide: "#exception-class-messages"
+  Enabled: true
+  VersionAdded: '0.14'
+  VersionChanged: '0.40'
+  EnforcedStyle: exploded
+  SupportedStyles:
+  - compact
+  - exploded
+
+# Supports --auto-correct
+Style/RandomWithOffset:
+  Description: Prefer to use ranges when generating random numbers instead of integers
+    with offsets.
+  StyleGuide: "#random-numbers"
+  Enabled: true
+  VersionAdded: '0.52'
+
+# Supports --auto-correct
+Style/RedundantBegin:
+  Description: Don't use begin blocks when they are not needed.
+  StyleGuide: "#begin-implicit"
+  Enabled: true
+  VersionAdded: '0.10'
+  VersionChanged: '0.21'
+
+# Supports --auto-correct
+Style/RedundantCapitalW:
+  Description: Checks for %W when interpolation is not needed.
+  Enabled: true
+  VersionAdded: '0.76'
+
+# Supports --auto-correct
+Style/RedundantCondition:
+  Description: Checks for unnecessary conditional expressions.
+  Enabled: true
+  VersionAdded: '0.76'
+
+# Supports --auto-correct
+Style/RedundantConditional:
+  Description: Don't return true/false from a conditional.
+  Enabled: true
+  VersionAdded: '0.50'
+
+# Supports --auto-correct
+Style/RedundantException:
+  Description: Checks for an obsolete RuntimeException argument in raise/fail.
+  StyleGuide: "#no-explicit-runtimeerror"
+  Enabled: true
+  VersionAdded: '0.14'
+  VersionChanged: '0.29'
+
+# Supports --auto-correct
+Style/RedundantFetchBlock:
+  Description: Use `fetch(key, value)` instead of `fetch(key) { value }` when value
+    has Numeric, Rational, Complex, Symbol or String type, `false`, `true`, `nil` or
+    is a constant.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#hashfetch-with-argument-vs-hashfetch--block-code
+  Enabled: true
+  Safe: false
+  SafeForConstants: false
+  VersionAdded: '0.86'
+
+# Supports --auto-correct
+Style/RedundantFileExtensionInRequire:
+  Description: Checks for the presence of superfluous `.rb` extension in the filename
+    provided to `require` and `require_relative`.
+  StyleGuide: "#no-explicit-rb-to-require"
+  Enabled: true
+  VersionAdded: '0.88'
+
+# Supports --auto-correct
+Style/RedundantFreeze:
+  Description: Checks usages of Object#freeze on immutable objects.
+  Enabled: true
+  VersionAdded: '0.34'
+  VersionChanged: '0.66'
+
+# Supports --auto-correct
+Style/RedundantInterpolation:
+  Description: Checks for strings that are just an interpolated expression.
+  Enabled: true
+  VersionAdded: '0.76'
+
+# Supports --auto-correct
+Style/RedundantParentheses:
+  Description: Checks for parentheses that seem not to serve any purpose.
+  Enabled: true
+  VersionAdded: '0.36'
+
+# Supports --auto-correct
+Style/RedundantPercentQ:
+  Description: Checks for %q/%Q when single quotes or double quotes would do.
+  StyleGuide: "#percent-q"
+  Enabled: true
+  VersionAdded: '0.76'
+
+# Supports --auto-correct
+Style/RedundantRegexpCharacterClass:
+  Description: Checks for unnecessary single-element Regexp character classes.
+  Enabled: true
+  VersionAdded: '0.85'
+
+# Supports --auto-correct
+Style/RedundantReturn:
+  Description: Don't use return where it's not required.
+  StyleGuide: "#no-explicit-return"
+  Enabled: true
+  VersionAdded: '0.10'
+  VersionChanged: '0.14'
+  AllowMultipleReturnValues: false
+
+# Supports --auto-correct
+Style/RedundantSelf:
+  Description: Don't use self where it's not needed.
+  StyleGuide: "#no-self-unless-required"
+  Enabled: true
+  VersionAdded: '0.10'
+  VersionChanged: '0.13'
+
+# Supports --auto-correct
+Style/RedundantSelfAssignment:
+  Description: Checks for places where redundant assignments are made for in place modification
+    methods.
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.90'
+
+# Supports --auto-correct
+Style/RedundantSort:
+  Description: Use `min` instead of `sort.first`, `max_by` instead of `sort_by...last`,
+    etc.
+  Enabled: true
+  VersionAdded: '0.76'
+
+# Supports --auto-correct
+Style/RedundantSortBy:
+  Description: Use `sort` instead of `sort_by { |x| x }`.
+  Enabled: true
+  VersionAdded: '0.36'
+
+# Supports --auto-correct
+Style/RegexpLiteral:
+  Description: Use / or %r around regular expressions.
+  StyleGuide: "#percent-r"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.30'
+  EnforcedStyle: slashes
+  SupportedStyles:
+  - slashes
+  - percent_r
+  - mixed
+  AllowInnerSlashes: false
+
+# Supports --auto-correct
+Style/RescueModifier:
+  Description: Avoid using rescue in its modifier form.
+  StyleGuide: "#no-rescue-modifiers"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.34'
+
+# Supports --auto-correct
+Style/RescueStandardError:
+  Description: Avoid rescuing without specifying an error class.
+  Enabled: true
+  VersionAdded: '0.52'
+  EnforcedStyle: explicit
+  SupportedStyles:
+  - implicit
+  - explicit
+
+# Supports --auto-correct
+Style/ReturnNil:
+  Description: Use return instead of return nil.
+  Enabled: false
+  EnforcedStyle: return
+  SupportedStyles:
+  - return
+  - return_nil
+  VersionAdded: '0.50'
+
+# Supports --auto-correct
+Style/SafeNavigation:
+  Description: This cop transforms usages of a method call safeguarded by a check for
+    the existence of the object to safe navigation (`&.`). Auto-correction is unsafe
+    as it assumes the object will be `nil` or truthy, but never `false`.
+  Enabled: true
+  VersionAdded: '0.43'
+  VersionChanged: '0.77'
+  ConvertCodeThatCanStartToReturnNil: false
+  AllowedMethods:
+  - present?
+  - blank?
+  - presence
+  - try
+  - try!
+  SafeAutoCorrect: false
+
+# Supports --auto-correct
+Style/Sample:
+  Description: Use `sample` instead of `shuffle.first`, `shuffle.last`, and `shuffle[Integer]`.
+  Reference: https://github.com/JuanitoFatas/fast-ruby#arrayshufflefirst-vs-arraysample-code
+  Enabled: true
+  VersionAdded: '0.30'
+
+# Supports --auto-correct
+Style/SelfAssignment:
+  Description: Checks for places where self-assignment shorthand should have been used.
+  StyleGuide: "#self-assignment"
+  Enabled: true
+  VersionAdded: '0.19'
+  VersionChanged: '0.29'
+
+# Supports --auto-correct
+Style/Semicolon:
+  Description: Don't use semicolons to terminate expressions.
+  StyleGuide: "#no-semicolon"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.19'
+  AllowAsExpressionSeparator: false
+
+Style/Send:
+  Description: Prefer `Object#__send__` or `Object#public_send` to `send`, as `send`
+    may overlap with existing methods.
+  StyleGuide: "#prefer-public-send"
+  Enabled: false
+  VersionAdded: '0.33'
+
+# Supports --auto-correct
+Style/SignalException:
+  Description: Checks for proper usage of fail and raise.
+  StyleGuide: "#prefer-raise-over-fail"
+  Enabled: true
+  VersionAdded: '0.11'
+  VersionChanged: '0.37'
+  EnforcedStyle: only_raise
+  SupportedStyles:
+  - only_raise
+  - only_fail
+  - semantic
+
+# Supports --auto-correct
+Style/SingleArgumentDig:
+  Description: Avoid using single argument dig method.
+  Enabled: true
+  VersionAdded: '0.89'
+  Safe: false
+
+Style/SingleLineBlockParams:
+  Description: Enforces the names of some block params.
+  Enabled: false
+  VersionAdded: '0.16'
+  VersionChanged: '0.47'
+  Methods:
+  - reduce:
+    - acc
+    - elem
+  - inject:
+    - acc
+    - elem
+
+# Supports --auto-correct
+Style/SingleLineMethods:
+  Description: Avoid single-line methods.
+  StyleGuide: "#no-single-line-methods"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.19'
+  AllowIfMethodIsEmpty: true
+
+# Supports --auto-correct
+Style/SlicingWithRange:
+  Description: Checks array slicing is done with endless ranges when suitable.
+  Enabled: true
+  VersionAdded: '0.83'
+  Safe: false
+
+Style/SoleNestedConditional:
+  Description: Finds sole nested conditional nodes which can be merged into outer conditional
+    node.
+  Enabled: true
+  VersionAdded: '0.89'
+  AllowModifier: false
+
+# Supports --auto-correct
+Style/SpecialGlobalVars:
+  Description: Avoid Perl-style global variables.
+  StyleGuide: "#no-cryptic-perlisms"
+  Enabled: true
+  VersionAdded: '0.13'
+  VersionChanged: '0.36'
+  SafeAutoCorrect: false
+  EnforcedStyle: use_english_names
+  SupportedStyles:
+  - use_perl_names
+  - use_english_names
+
+# Supports --auto-correct
+Style/StabbyLambdaParentheses:
+  Description: Check for the usage of parentheses around stabby lambda arguments.
+  StyleGuide: "#stabby-lambda-with-args"
+  Enabled: true
+  VersionAdded: '0.35'
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+  - require_parentheses
+  - require_no_parentheses
+
+# Supports --auto-correct
+Style/StderrPuts:
+  Description: Use `warn` instead of `$stderr.puts`.
+  StyleGuide: "#warn"
+  Enabled: true
+  VersionAdded: '0.51'
+
+# Supports --auto-correct
+Style/StringHashKeys:
+  Description: Prefer symbols instead of strings as hash keys.
+  StyleGuide: "#symbols-as-keys"
+  Enabled: false
+  VersionAdded: '0.52'
+  VersionChanged: '0.75'
+  Safe: false
+
+# Supports --auto-correct
 Style/StringLiterals:
+  Description: Checks if uses of quotes match the configured preference.
+  StyleGuide: "#consistent-string-literals"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.36'
   EnforcedStyle: double_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes
+  ConsistentQuotesInMultiline: false
 
-Layout/ExtraSpacing:
-  AllowForAlignment: false
+# Supports --auto-correct
+Style/StringLiteralsInInterpolation:
+  Description: Checks if uses of quotes inside expressions in interpolated strings match
+    the configured preference.
+  Enabled: true
+  VersionAdded: '0.27'
+  EnforcedStyle: single_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes
 
-Layout/LineLength:
+# Supports --auto-correct
+Style/StringMethods:
+  Description: Checks if configured preferred methods are used over non-preferred.
   Enabled: false
+  VersionAdded: '0.34'
+  VersionChanged: 0.34.2
+  PreferredMethods:
+    intern: to_sym
+
+# Supports --auto-correct
+Style/Strip:
+  Description: Use `strip` instead of `lstrip.rstrip`.
+  Enabled: true
+  VersionAdded: '0.36'
+
+# Supports --auto-correct
+Style/StructInheritance:
+  Description: Checks for inheritance from Struct.new.
+  StyleGuide: "#no-extend-struct-new"
+  Enabled: true
+  VersionAdded: '0.29'
+  VersionChanged: '0.86'
+
+# Supports --auto-correct
+Style/SymbolArray:
+  Description: Use %i or %I for arrays of symbols.
+  StyleGuide: "#percent-i"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.49'
+  EnforcedStyle: percent
+  MinSize: 2
+  SupportedStyles:
+  - percent
+  - brackets
+
+# Supports --auto-correct
+Style/SymbolLiteral:
+  Description: Use plain symbols instead of string symbols when possible.
+  Enabled: true
+  VersionAdded: '0.30'
+
+# Supports --auto-correct
+Style/SymbolProc:
+  Description: Use symbols as procs instead of blocks when possible.
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.26'
+  VersionChanged: '0.64'
+  IgnoredMethods:
+  - respond_to
+  - define_method
+
+# Supports --auto-correct
+Style/TernaryParentheses:
+  Description: Checks for use of parentheses around ternary conditions.
+  Enabled: true
+  VersionAdded: '0.42'
+  VersionChanged: '0.46'
+  EnforcedStyle: require_no_parentheses
+  SupportedStyles:
+  - require_parentheses
+  - require_no_parentheses
+  - require_parentheses_when_complex
+  AllowSafeAssignment: true
+
+# Supports --auto-correct
+Style/TrailingBodyOnClass:
+  Description: Class body goes below class statement.
+  Enabled: true
+  VersionAdded: '0.53'
+
+# Supports --auto-correct
+Style/TrailingBodyOnMethodDefinition:
+  Description: Method body goes below definition.
+  Enabled: true
+  VersionAdded: '0.52'
+
+# Supports --auto-correct
+Style/TrailingBodyOnModule:
+  Description: Module body goes below module statement.
+  Enabled: true
+  VersionAdded: '0.53'
+
+# Supports --auto-correct
+Style/TrailingCommaInArguments:
+  Description: Checks for trailing comma in argument lists.
+  StyleGuide: "#no-trailing-params-comma"
+  Enabled: true
+  VersionAdded: '0.36'
+  EnforcedStyleForMultiline: no_comma
+  SupportedStylesForMultiline:
+  - comma
+  - consistent_comma
+  - no_comma
+
+# Supports --auto-correct
+Style/TrailingCommaInArrayLiteral:
+  Description: Checks for trailing comma in array literals.
+  StyleGuide: "#no-trailing-array-commas"
+  Enabled: true
+  VersionAdded: '0.53'
+  EnforcedStyleForMultiline: no_comma
+  SupportedStylesForMultiline:
+  - comma
+  - consistent_comma
+  - no_comma
+
+# Supports --auto-correct
+Style/TrailingCommaInBlockArgs:
+  Description: Checks for useless trailing commas in block arguments.
+  Enabled: false
+  Safe: false
+  VersionAdded: '0.81'
+
+# Supports --auto-correct
+Style/TrailingCommaInHashLiteral:
+  Description: Checks for trailing comma in hash literals.
+  Enabled: true
+  EnforcedStyleForMultiline: no_comma
+  SupportedStylesForMultiline:
+  - comma
+  - consistent_comma
+  - no_comma
+  VersionAdded: '0.53'
+
+# Supports --auto-correct
+Style/TrailingMethodEndStatement:
+  Description: Checks for trailing end statement on line of method body.
+  Enabled: true
+  VersionAdded: '0.52'
+
+# Supports --auto-correct
+Style/TrailingUnderscoreVariable:
+  Description: Checks for the usage of unneeded trailing underscores at the end of parallel
+    variable assignment.
+  AllowNamedUnderscoreVariables: true
+  Enabled: true
+  VersionAdded: '0.31'
+  VersionChanged: '0.35'
+
+# Supports --auto-correct
+Style/TrivialAccessors:
+  Description: Prefer attr_* methods to trivial readers/writers.
+  StyleGuide: "#attr_family"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.77'
+  ExactNameMatch: true
+  AllowPredicates: true
+  AllowDSLWriters: false
+  IgnoreClassMethods: false
+  AllowedMethods:
+  - to_ary
+  - to_a
+  - to_c
+  - to_enum
+  - to_h
+  - to_hash
+  - to_i
+  - to_int
+  - to_io
+  - to_open
+  - to_path
+  - to_proc
+  - to_r
+  - to_regexp
+  - to_str
+  - to_s
+  - to_sym
+
+# Supports --auto-correct
+Style/UnlessElse:
+  Description: Do not use unless with else. Rewrite these with the positive case first.
+  StyleGuide: "#no-else-with-unless"
+  Enabled: true
+  VersionAdded: '0.9'
+
+# Supports --auto-correct
+Style/UnpackFirst:
+  Description: Checks for accessing the first element of `String#unpack` instead of
+    using `unpack1`.
+  Enabled: true
+  VersionAdded: '0.54'
+
+# Supports --auto-correct
+Style/VariableInterpolation:
+  Description: Don't interpolate global, instance and class variables directly in strings.
+  StyleGuide: "#curlies-interpolate"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.20'
+
+# Supports --auto-correct
+Style/WhenThen:
+  Description: Use when x then ... for one-line cases.
+  StyleGuide: "#one-line-cases"
+  Enabled: true
+  VersionAdded: '0.9'
+
+# Supports --auto-correct
+Style/WhileUntilDo:
+  Description: Checks for redundant do after while or until.
+  StyleGuide: "#no-multiline-while-do"
+  Enabled: true
+  VersionAdded: '0.9'
+
+# Supports --auto-correct
+Style/WhileUntilModifier:
+  Description: Favor modifier while/until usage when you have a single-line body.
+  StyleGuide: "#while-as-a-modifier"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.30'
+
+# Supports --auto-correct
+Style/WordArray:
+  Description: Use %w or %W for arrays of words.
+  StyleGuide: "#percent-w"
+  Enabled: true
+  VersionAdded: '0.9'
+  VersionChanged: '0.36'
+  EnforcedStyle: percent
+  SupportedStyles:
+  - percent
+  - brackets
+  MinSize: 2
+  WordRegex: !ruby/regexp /\A(?:\p{Word}|\p{Word}-\p{Word}|\n|\t)+\z/
+
+# Supports --auto-correct
+Style/YodaCondition:
+  Description: Forbid or enforce yoda conditions.
+  Reference: https://en.wikipedia.org/wiki/Yoda_conditions
+  Enabled: true
+  EnforcedStyle: forbid_for_all_comparison_operators
+  SupportedStyles:
+  - forbid_for_all_comparison_operators
+  - forbid_for_equality_operators_only
+  - require_for_all_comparison_operators
+  - require_for_equality_operators_only
+  Safe: false
+  VersionAdded: '0.49'
+  VersionChanged: '0.75'
+
+# Supports --auto-correct
+Style/ZeroLengthPredicate:
+  Description: 'Use #empty? when testing for objects of length 0.'
+  Enabled: true
+  Safe: false
+  VersionAdded: '0.37'
+  VersionChanged: '0.39'


### PR DESCRIPTION
I want to enforce what I was enforcing before, but don't want to keep up with new cops, so disabled by default from now on.