### PR TITLE
Bring conditions back to start with pry-byebug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master (Unreleased)
 
+### Fixed
+
+* Rails console loading a debugger REPL instead of the standard Pry REPL (#392)
+
 ## 3.10.0 (2022-08-15)
 
 ### Added

--- a/lib/pry-byebug/pry_ext.rb
+++ b/lib/pry-byebug/pry_ext.rb
@@ -5,8 +5,15 @@ require "byebug/processors/pry_processor"
 class << Pry::REPL
   alias start_without_pry_byebug start
 
-  def start_with_pry_byebug(_ = {})
-    Byebug::PryProcessor.start unless ENV["DISABLE_PRY"]
+  def start_with_pry_byebug(options = {})
+    target = options[:target]
+
+    if target.is_a?(Binding) && PryByebug.file_context?(target)
+      Byebug::PryProcessor.start unless ENV["DISABLE_PRY"]
+    else
+      # No need for the tracer unless we have a file context to step through
+      start_without_pry_byebug(options)
+    end
   end
 
   alias start start_with_pry_byebug


### PR DESCRIPTION
The latest version breaks rails-console and it triggers debugger REPL instead of standard Pry REPL.

Fixes #391 