### PR TITLE
Disable pry-byebug when invoked by pry-rescue

### DIFF
--- a/lib/pry-byebug/pry_ext.rb
+++ b/lib/pry-byebug/pry_ext.rb
@@ -8,7 +8,7 @@ class << Pry::REPL
   def start_with_pry_byebug(options = {})
     target = options[:target]
 
-    if target.is_a?(Binding) && PryByebug.file_context?(target)
+    if target.is_a?(Binding) && PryByebug.file_context?(target) && !options[:hooks]&.hook_exists?(:before_session, :save_captured_exception)
       Byebug::PryProcessor.start unless ENV["DISABLE_PRY"]
     else
       # No need for the tracer unless we have a file context to step through


### PR DESCRIPTION
See https://github.com/ConradIrwin/pry-rescue/issues/124 --- pry-byebug doesn't play nicely with pry-rescue. pry-rescue works by capturing the call stack, and later invoking pry using that call stack (not the current one) as the target.

I think the *correct* fix would be to allow [ByeBug::PryProcessor.start](https://github.com/deivid-rodriguez/pry-byebug/blob/4eb7421103985215d404d42d3ed74cfec15f0102/lib/byebug/processors/pry_processor.rb#L16-L21) (called from [here](https://github.com/deivid-rodriguez/pry-byebug/blob/4eb7421103985215d404d42d3ed74cfec15f0102/lib/pry-byebug/pry_ext.rb#L12)) to receive a `target` and use that to initialize the context of byebug. But there doesn't seem to be an easy way to modify byebug to operate within an arbitrary call stack.

So as a workaround for now, just disable the use of byebug when pry was entered via pry-rescue. We can detect this by the presence of the `save_captured_exception` hook.