### PR TITLE
Make the pry-byebug compatible with pry-remote gem

### DIFF
--- a/lib/byebug/processors/pry_remote_processor.rb
+++ b/lib/byebug/processors/pry_remote_processor.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "byebug/core"
+
+module Byebug
+  #
+  # Extends the PryProcessor to make it work with Pry-Remote
+  #
+  class PryRemoteProcessor < PryProcessor
+    def self.start
+      super
+
+      Byebug.current_context.step_out(5, true)
+    end
+
+    def resume_pry
+      new_binding = frame._binding
+
+      run do
+        if defined?(@pry) && @pry
+          @pry.repl(new_binding)
+        else
+          @pry = Pry.start_without_pry_byebug(new_binding, input: input, output: output)
+        end
+      end
+    end
+
+    private
+
+    def input
+      server.client.input_proxy
+    end
+
+    def output
+      server.client.output
+    end
+
+    def server
+      PryByebug.current_remote_server
+    end
+  end
+end

--- a/lib/pry-byebug/base.rb
+++ b/lib/pry-byebug/base.rb
@@ -7,7 +7,9 @@ require "pry-byebug/helpers/location"
 #
 module PryByebug
   # Reference to currently running pry-remote server. Used by the processor.
-  attr_accessor :current_remote_server
+  class << self
+    attr_accessor :current_remote_server
+  end
 
   module_function
 

--- a/lib/pry-byebug/commands/exit_all.rb
+++ b/lib/pry-byebug/commands/exit_all.rb
@@ -10,6 +10,7 @@ module PryByebug
     def process
       super
     ensure
+      PryByebug.current_remote_server&.teardown
       Byebug.stop if Byebug.stoppable?
     end
   end

--- a/lib/pry-byebug/commands/finish.rb
+++ b/lib/pry-byebug/commands/finish.rb
@@ -18,6 +18,7 @@ module PryByebug
     BANNER
 
     def process
+      PryByebug.current_remote_server&.teardown
       PryByebug.check_file_context(target)
 
       breakout_navigation :finish

--- a/lib/pry-byebug/pry_ext.rb
+++ b/lib/pry-byebug/pry_ext.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "byebug/processors/pry_processor"
+require "byebug/processors/pry_remote_processor"
 
 class << Pry::REPL
   alias start_without_pry_byebug start
@@ -8,12 +9,16 @@ class << Pry::REPL
   def start_with_pry_byebug(options = {})
     target = options[:target]
 
-    if target.is_a?(Binding) && PryByebug.file_context?(target)
-      Byebug::PryProcessor.start unless ENV["DISABLE_PRY"]
+    if target.is_a?(Binding) && PryByebug.file_context?(target) 
+      run_remote? ? Byebug::PryRemoteProcessor.start : Byebug::PryProcessor.start unless ENV["DISABLE_PRY"]
     else
       # No need for the tracer unless we have a file context to step through
       start_without_pry_byebug(options)
     end
+  end
+
+  def run_remote?
+    PryByebug.current_remote_server
   end
 
   alias start start_with_pry_byebug


### PR DESCRIPTION
I couldn't find a better way to pass the `pry-remote` input and output
to pry instance without changing a lot of the byebug processors, This
is why I had to use the `Context.interface`.