### PR TITLE
Update Ruby versions in CI

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.7.6, 3.0.4, 3.1.2]
+        ruby: [3.0.7, 3.1.6, 3.2.7, 3.3.7, 3.4.2]
 
     env:
       BUNDLE_PATH: .bundle


### PR DESCRIPTION
This pull request removes the old `2.7` ruby version, and adds support to the 3.3 and 3.4.