### PR TITLE
Workaround octokit warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,11 @@ group :development do
   gem "rake", "~> 13.0"
 
   gem "chandler", "0.9.0"
+
+  # To workaround octokit warning. Can be removed once
+  # https://github.com/octokit/octokit.rb/pull/1706 is released
+  gem "faraday-retry"
+
   gem "mdl", "0.13.0"
   gem "minitest", "~> 5.14"
   gem "minitest-bisect", "~> 1.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,8 @@ GEM
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
+    faraday-retry (2.2.1)
+      faraday (~> 2.0)
     json (2.10.2)
     kramdown (2.5.1)
       rexml (>= 3.3.9)
@@ -103,6 +105,7 @@ PLATFORMS
 
 DEPENDENCIES
   chandler (= 0.9.0)
+  faraday-retry
   mdl (= 0.13.0)
   minitest (~> 5.14)
   minitest-bisect (~> 1.5)


### PR DESCRIPTION
> To use retry middleware with Faraday v2.0+, install `faraday-retry` gem